### PR TITLE
Fix cached responses blocking contact loading

### DIFF
--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -1,5 +1,8 @@
 // client/src/lib/api-client.ts
 export async function handleResponse<T>(response: Response): Promise<T | undefined> {
+  // Treat 304 Not Modified as a valid empty response
+  if (response.status === 304) return undefined;
+
   if (!response.ok) {
     let msg = `Request failed: ${response.status}`;
     try {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,6 +17,9 @@ import { isAuthenticated } from './middleware/auth';
 export function createApp(): Express {
   const app: Express = express();
 
+  // Disable ETag to avoid 304 responses which break simple fetch helpers
+  app.set('etag', false);
+
   /* ───────── SESSIONS ───────── */
   const sess = session({
     secret: process.env.SESSION_SECRET ?? 'dev‑secret',


### PR DESCRIPTION
## Summary
- disable Express etag generation so the server doesn't return 304
- allow client API helper to handle HTTP 304 without throwing

## Testing
- `npx jest` *(fails: request to registry.npmjs.org failed)*