### PR TITLE
Change backend port to 4269

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,4 @@ NODE_ENV=development
 # Database connection string (update with your credentials).
 POSTGRES_URL=postgres://postgres:postgres@localhost:5432/mess
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/mess
-VITE_API_URL=
+VITE_API_URL=http://localhost:4269

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=""
+VITE_API_URL=http://localhost:4269

--- a/.replit
+++ b/.replit
@@ -11,8 +11,8 @@ build = ["npm", "run", "build"]
 run = ["npm", "run", "start"]
 
 [[ports]]
-localPort = 3000
-externalPort = 3000
+localPort = 4269
+externalPort = 4269
 
 [[ports]]
 localPort = 5000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guidelines
+
+- Use port **4269** for the backend API and WebSocket server.
+- Update client code accordingly when changing endpoints.

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -32,7 +32,9 @@ export function useWebSocket(): WebSocketHook {
       return;
     }
 
-    const base = api?.isElectron ? `ws://localhost:3000` : `${window.location.origin.replace(/^http/, "ws")}`;
+    const base = api?.isElectron
+      ? `ws://localhost:4269`
+      : `${window.location.origin.replace(/^http/, "ws")}`;
 
     socket.current = new WebSocket(`${base}?userId=${user.id}`);
 

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 
-const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:4269";
 
 export function createApiClient(isElectron: boolean) {
   const getBaseUrl = () => (isElectron ? API_URL : "");

--- a/client/src/lib/useWebSocket.ts
+++ b/client/src/lib/useWebSocket.ts
@@ -73,7 +73,9 @@ export function useWebSocket(): WebSocketHook {
 
     // Setup WebSocket connection
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const apiUrl = new URL(import.meta.env.VITE_API_URL ?? "http://localhost:3000");
+    const apiUrl = new URL(
+      import.meta.env.VITE_API_URL ?? "http://localhost:4269"
+    );
     const wsUrl = `${protocol}//${apiUrl.host}/ws`;
 
     let socket: WebSocket;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
       proxy: {
         '/api': {
-          target: env.VITE_API_URL || 'http://localhost:3000',
+          target: env.VITE_API_URL || 'http://localhost:4269',
           changeOrigin: true
         }
       }


### PR DESCRIPTION
## Summary
- update docs with backend port info
- change default API/WS port to 4269 across client config
- adjust .replit ports and env files

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*