### PR TITLE
Fix electron paths for local dev

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1,5 +1,8 @@
 import { app, BrowserWindow, ipcMain, IpcMainEvent } from 'electron';
-import path from 'node:path';
+import path, { resolve } from 'node:path';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: resolve(__dirname, '../../.env') });
 
 let mainWindow: Electron.BrowserWindow | null = null;
 const isDev = !!process.env.VITE_DEV_SERVER_URL;
@@ -25,7 +28,7 @@ function createMainWindow() {
     win.loadURL(process.env.VITE_DEV_SERVER_URL);
     win.webContents.openDevTools();
   } else {
-    win.loadFile(path.join(__dirname, './renderer/index.html'));
+    win.loadFile(path.join(__dirname, '../../client/dist/index.html'));
   }
 
   // подписка на событие закрытия


### PR DESCRIPTION
## Summary
- load environment variables in the electron process
- correct production index.html path for the electron app

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*