### PR TITLE
Fix message sending and env load

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1,5 +1,8 @@
 import { app, BrowserWindow, ipcMain, IpcMainEvent } from 'electron';
 import path from 'node:path';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 let mainWindow: Electron.BrowserWindow | null = null;
 const isDev = !!process.env.VITE_DEV_SERVER_URL;
@@ -25,7 +28,7 @@ function createMainWindow() {
     win.loadURL(process.env.VITE_DEV_SERVER_URL);
     win.webContents.openDevTools();
   } else {
-    win.loadFile(path.join(__dirname, './renderer/index.html'));
+    win.loadFile(path.join(__dirname, '../../client/dist/index.html'));
   }
 
   // подписка на событие закрытия

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -199,8 +199,7 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
 
     // Если оба онлайн, пересылаем через WS:
     // Note: The sendChatMessage function needs to handle the logic of checking if the receiver is online.
-    sendChatMessage(receiverId,
-+   { senderId, receiverId, content });
+    sendChatMessage(receiverId, { senderId, receiverId, content });
 
     res.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary
- load dotenv using path.resolve
- fix sendChatMessage parameter typo causing 500 errors

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*