### PR TITLE
Fix Electron preload module format

### DIFF
--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "CommonJS",
     "target": "ES2022",
     "types": [
       "vite/client",


### PR DESCRIPTION
## Summary
- set `electron/tsconfig.json` to compile CommonJS modules

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*