### PR TITLE
Fix logout and improve chat messages

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -188,13 +188,15 @@ export default function MessagesSection({ onStartCall }: Props) {
       });
     }
 
-    appendMessage(user!.id, selectedUser.id, {
+    const msg = {
       id: Date.now(),
       senderId: user!.id,
       receiverId: selectedUser.id,
       content: msgInput,
       timestamp: new Date().toISOString(),
-    });
+    };
+    appendMessage(user!.id, selectedUser.id, msg);
+    setLocalMessages((prev) => [...prev, msg]);
 
     setMsgInput('');
     refetchHistory();
@@ -306,6 +308,10 @@ export default function MessagesSection({ onStartCall }: Props) {
             <div className="flex-1 overflow-y-auto p-4 space-y-3">
               {isLoadingMessages ? (
                 <Loader2 className="h-5 w-5 animate-spin" />
+              ) : messages.length === 0 && localMessages.length === 0 ? (
+                <p className="text-gray-500 text-sm">
+                  {t('messages.noMessages')}
+                </p>
               ) : (
                 (messages.length > 0 ? messages : localMessages).map((m) => (
                   <div

--- a/client/src/pages/settings-section.tsx
+++ b/client/src/pages/settings-section.tsx
@@ -1,14 +1,35 @@
 import { useAuth } from "../hooks/use-auth";
+import { useTranslations } from "@/hooks/use-translations";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 
 export default function SettingsSection() {
   const { user } = useAuth();
+  const { t, currentLanguage, changeLanguage } = useTranslations();
 
   if (!user) return null;
 
   return (
     <div className="flex-1 overflow-auto p-6">
-      <h2>Settings</h2>
-      <p>Nothing here yet – wire up your preferences UI later.</p>
+      <h2 className="text-xl font-semibold mb-4">{t('settings.title')}</h2>
+      <div className="space-y-2 max-w-xs">
+        <Label htmlFor="language">{t('settings.language')}</Label>
+        <Select value={currentLanguage} onValueChange={changeLanguage}>
+          <SelectTrigger id="language">
+            <SelectValue placeholder={t('settings.language')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ru">Русский</SelectItem>
+            <SelectItem value="en">English</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -41,7 +41,18 @@ router.post('/register', async (req: Request, res: Response) => {
      logger.error('Register failed:', error);
      res.status(500).json({ error: 'Registration error' });
    }
- });
+});
+
+router.post('/logout', (req: Request, res: Response) => {
+  req.session.destroy(err => {
+    if (err) {
+      logger.error('Logout error:', err);
+      return res.status(500).json({ error: 'Logout failed' });
+    }
+    res.clearCookie('connect.sid');
+    res.json({ success: true });
+  });
+});
 
 router.get('/user', async (req, res) => {
   const userId = (req.session as any).userId;


### PR DESCRIPTION
## Summary
- implement POST `/logout` endpoint to destroy session
- add language select to settings section
- update chat logic to keep local state and show placeholder when no messages

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*