### PR TITLE
Implement cross-device message sync

### DIFF
--- a/client/src/hooks/useMessageSync.ts
+++ b/client/src/hooks/useMessageSync.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useAuth } from '@/hooks/use-auth';
+import { createApiClient } from '@/lib/api-client';
+import {
+  getUnsyncedMessages,
+  markMessagesSynced,
+  appendMessage,
+  StoredMessage,
+} from '@/lib/message-storage';
+
+export function useMessageSync() {
+  const { user } = useAuth();
+  const apiClient = createApiClient();
+
+  useEffect(() => {
+    if (!user) return;
+
+    const sync = async () => {
+      const unsynced = getUnsyncedMessages(user.id);
+      for (const { otherId, messages } of unsynced) {
+        if (messages.length === 0) continue;
+        try {
+          await apiClient.request('/sync/messages', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(messages),
+          });
+          markMessagesSynced(user.id, otherId, messages.map((m) => m.id));
+        } catch (err) {
+          console.error('Message sync failed', err);
+        }
+      }
+
+      try {
+        const incoming = await apiClient.request<StoredMessage[]>('/sync/messages');
+        if (incoming) {
+          for (const msg of incoming) {
+            appendMessage(msg.senderId, msg.receiverId, { ...msg, synced: true });
+          }
+        }
+      } catch (err) {
+        console.error('Fetch sync messages failed', err);
+      }
+    };
+
+    sync();
+    const interval = setInterval(sync, 30_000);
+    return () => clearInterval(interval);
+  }, [user]);
+}

--- a/client/src/lib/message-storage.ts
+++ b/client/src/lib/message-storage.ts
@@ -4,6 +4,7 @@ export interface StoredMessage {
   receiverId: number;
   content: string;
   timestamp: string;
+  synced?: boolean;
 }
 
 function key(myId: number, otherId: number) {
@@ -24,6 +25,25 @@ export function appendMessage(myId: number, otherId: number, message: StoredMess
   msgs.push(message);
   saveMessages(myId, otherId, msgs);
   console.info('Message stored in localStorage', { myId, otherId, message });
+}
+
+export function getConversationKeys(myId: number): string[] {
+  return Object.keys(localStorage).filter((k) => k.startsWith(`msgs-${myId}-`));
+}
+
+export function getUnsyncedMessages(myId: number): { otherId: number; messages: StoredMessage[] }[] {
+  return getConversationKeys(myId).map((k) => {
+    const otherId = Number(k.split('-')[2]);
+    const msgs = loadMessages(myId, otherId).filter((m) => !m.synced);
+    return { otherId, messages: msgs };
+  });
+}
+
+export function markMessagesSynced(myId: number, otherId: number, ids: number[]): void {
+  const msgs = loadMessages(myId, otherId).map((m) =>
+    ids.includes(m.id) ? { ...m, synced: true } : m,
+  );
+  saveMessages(myId, otherId, msgs);
 }
 
 export function clearMessages(myId: number, otherId: number): void {

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -12,6 +12,7 @@ import CallModal from "@/components/call-modal";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { SectionType } from "@/types/sections";
 import { useChat } from "@/context/ChatContext";
+import { useMessageSync } from "@/hooks/useMessageSync";
 
 export default function HomePage() {
   const [activeSection, setActiveSection] = useState<SectionType>("messages");
@@ -24,6 +25,7 @@ export default function HomePage() {
   } | null>(null);
   const { connectionStatus } = useWebSocket();
   const { setChatUser } = useChat();
+  useMessageSync();
 
   const handleStartCall = (
     type: "video" | "audio",

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -5,7 +5,12 @@ import { useChat } from '@/context/ChatContext';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { usePeerConnection } from '@/hooks/usePeerConnection';
 import { createApiClient } from '@/lib/api-client';
-import { loadMessages, saveMessages, appendMessage } from '@/lib/message-storage';
+import {
+  loadMessages,
+  saveMessages,
+  appendMessage,
+  StoredMessage,
+} from '@/lib/message-storage';
 import { Send, Loader2, Phone, Video, ArrowLeft } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -200,12 +205,13 @@ export default function MessagesSection({ onStartCall }: Props) {
       });
     }
 
-    const msg = {
+    const msg: StoredMessage = {
       id: Date.now(),
       senderId: user!.id,
       receiverId: selectedUser.id,
       content: msgInput,
       timestamp: new Date().toISOString(),
+      synced: false,
     };
     appendMessage(user!.id, selectedUser.id, msg);
     setLocalMessages((prev) => [...prev, msg]);

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -10,6 +10,16 @@ import departmentsRouter from './departments';
 import wikiRouter from './wiki';
 import requestsRouter from './requests';
 
+interface SyncMessage {
+  id: number;
+  senderId: number;
+  receiverId: number;
+  content: string;
+  timestamp: string;
+}
+
+const syncStore = new Map<number, SyncMessage[]>();
+
 const router = Router();
 router.use('/departments', isAuthenticated, departmentsRouter);
 router.use('/requests', isAuthenticated, requestsRouter);
@@ -221,6 +231,21 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
     const detail = error instanceof Error ? error.message : String(error);
     res.status(500).json({ error: 'Server error', detail });
   }
+});
+
+router.post('/sync/messages', isAuthenticated, (req: Request, res: Response) => {
+  const userId = req.session.userId as number;
+  const msgs = Array.isArray(req.body) ? (req.body as SyncMessage[]) : [];
+  if (!syncStore.has(userId)) syncStore.set(userId, []);
+  syncStore.get(userId)!.push(...msgs);
+  res.json({ success: true });
+});
+
+router.get('/sync/messages', isAuthenticated, (req: Request, res: Response) => {
+  const userId = req.session.userId as number;
+  const msgs = syncStore.get(userId) ?? [];
+  syncStore.set(userId, []);
+  res.json(msgs);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- store sync flag with local messages
- track unsynced messages and mark them when sent
- add message sync hook with 30s interval
- use the hook on the home page
- expose `/sync/messages` endpoints on the server

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*