### PR TITLE
Fix missing settings translations

### DIFF
--- a/client/public/locales/ru/translation.json
+++ b/client/public/locales/ru/translation.json
@@ -43,6 +43,16 @@
     "theme": "Тема",
     "lightMode": "Светлая",
     "darkMode": "Темная",
-    "system": "Системная"
+    "system": "Системная",
+    "customizeAppearance": "Настройка внешнего вида приложения",
+    "changeLanguage": "Изменить язык приложения",
+    "manageAccount": "Управление учетной записью",
+    "accountSettings": "Настройки учетной записи",
+    "managePrivacy": "Управление конфиденциальностью",
+    "privacySettings": "Настройки конфиденциальности",
+    "manageNotifications": "Управление уведомлениями",
+    "emailNotificationsDescription": "Получать обновления по электронной почте",
+    "pushNotificationsDescription": "Получать push-уведомления на устройстве",
+    "desktopNotificationsDescription": "Получать уведомления на рабочем столе"
   }
 }

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -17,7 +17,9 @@
     "search": "Search",
     "filter": "Filter",
     "sortBy": "Sort by",
-    "welcome": "Welcome"
+    "welcome": "Welcome",
+    "enabled": "Enabled",
+    "disabled": "Disabled"
   },
   "auth": {
     "login": "Login",
@@ -108,7 +110,18 @@
     "changesApplied": "Changes applied successfully",
     "languageChanged": "Language Changed",
     "languageChangeSuccess": "Application language has been updated",
-    "languageChangeFailed": "Failed to change language"
+    "languageChangeFailed": "Failed to change language",
+    "system": "System",
+    "customizeAppearance": "Customize the application's look and feel",
+    "changeLanguage": "Change the application language",
+    "manageAccount": "Manage your account settings",
+    "accountSettings": "Account settings",
+    "managePrivacy": "Manage your privacy preferences",
+    "privacySettings": "Privacy settings",
+    "manageNotifications": "Manage notification preferences",
+    "emailNotificationsDescription": "Receive updates via email",
+    "pushNotificationsDescription": "Receive push notifications on your device",
+    "desktopNotificationsDescription": "Receive notifications on your desktop"
   },
   "messages": {
     "noChat": "No chat",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -17,7 +17,9 @@
     "search": "Поиск",
     "filter": "Фильтр",
     "sortBy": "Сортировать по",
-    "welcome": "Добро пожаловать"
+    "welcome": "Добро пожаловать",
+    "enabled": "Включено",
+    "disabled": "Отключено"
   },
   "auth": {
     "login": "Вход",
@@ -120,7 +122,18 @@
     "changesApplied": "Изменения успешно применены",
     "languageChanged": "Язык изменен",
     "languageChangeSuccess": "Язык приложения обновлён",
-    "languageChangeFailed": "Не удалось изменить язык"
+    "languageChangeFailed": "Не удалось изменить язык",
+    "system": "Системная",
+    "customizeAppearance": "Настройка внешнего вида приложения",
+    "changeLanguage": "Изменить язык приложения",
+    "manageAccount": "Управление учетной записью",
+    "accountSettings": "Настройки учетной записи",
+    "managePrivacy": "Управление параметрами конфиденциальности",
+    "privacySettings": "Настройки конфиденциальности",
+    "manageNotifications": "Управление уведомлениями",
+    "emailNotificationsDescription": "Получать обновления по электронной почте",
+    "pushNotificationsDescription": "Получать push-уведомления на устройстве",
+    "desktopNotificationsDescription": "Получать уведомления на рабочем столе"
   },
   "messages": {
     "title": "Сообщения",


### PR DESCRIPTION
## Summary
- add `enabled` and `disabled` strings
- fill in missing translations for the Settings page

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*