### PR TITLE
Fix websocket host

### DIFF
--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -32,9 +32,9 @@ export function useWebSocket(): WebSocketHook {
       return;
     }
 
-    const base = api?.isElectron
-      ? `ws://localhost:4269`
-      : `${window.location.origin.replace(/^http/, "ws")}`;
+    const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:4269";
+    const wsBase = apiUrl.replace(/^http/, "ws");
+    const base = wsBase;
 
     socket.current = new WebSocket(`${base}?userId=${user.id}`);
 


### PR DESCRIPTION
## Summary
- ensure useWebSocket hook always connects to server on port 4269

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*