### PR TITLE
Add local settings persistence

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,19 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script>
+    const stored = localStorage.getItem('userSettings');
+    try {
+      const { theme = 'system' } = stored ? JSON.parse(stored) : {};
+      document.documentElement.classList.remove('light', 'dark');
+      if (theme === 'system') {
+        const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.classList.add(prefersDark ? 'dark' : 'light');
+      } else {
+        document.documentElement.classList.add(theme);
+      }
+    } catch {}
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/client/src/hooks/use-settings.tsx
+++ b/client/src/hooks/use-settings.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import i18n from '@/i18n';
+
+export type Theme = 'light' | 'dark' | 'system';
+export type Language = 'en' | 'ru';
+
+export interface UserSettings {
+  theme: Theme;
+  language: Language;
+}
+
+interface SettingsContextValue {
+  settings: UserSettings;
+  setTheme: (theme: Theme) => void;
+  setLanguage: (lang: Language) => void;
+  updateSettings: (values: Partial<UserSettings>) => void;
+}
+
+const defaultSettings: UserSettings = {
+  theme: 'system',
+  language: 'ru',
+};
+
+const SETTINGS_KEY = 'userSettings';
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.remove('light', 'dark');
+  if (theme === 'system') {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.classList.add(prefersDark ? 'dark' : 'light');
+  } else {
+    document.documentElement.classList.add(theme);
+  }
+}
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<UserSettings>(() => {
+    try {
+      const raw = localStorage.getItem(SETTINGS_KEY);
+      return raw ? { ...defaultSettings, ...JSON.parse(raw) } : defaultSettings;
+    } catch {
+      return defaultSettings;
+    }
+  });
+
+  useEffect(() => {
+    applyTheme(settings.theme);
+    i18n.changeLanguage(settings.language).catch(console.error);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const setTheme = (theme: Theme) => {
+    setSettings((prev) => ({ ...prev, theme }));
+    applyTheme(theme);
+  };
+
+  const setLanguage = (lang: Language) => {
+    setSettings((prev) => ({ ...prev, language: lang }));
+    i18n.changeLanguage(lang).catch(console.error);
+  };
+
+  const updateSettings = (values: Partial<UserSettings>) => {
+    setSettings((prev) => ({ ...prev, ...values }));
+    if (values.theme) applyTheme(values.theme);
+    if (values.language) i18n.changeLanguage(values.language).catch(console.error);
+  };
+
+  return (
+    <SettingsContext.Provider value={{ settings, setTheme, setLanguage, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
+  return ctx;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import { installMockElectronAPI } from "./lib/web-polyfills";
+import { SettingsProvider } from "./hooks/use-settings";
+import { LanguageProvider } from "./lib/i18n/LanguageContext";
 
 // Install web polyfills if needed
 if (import.meta.env.VITE_WEB_ONLY === 'true' || !import.meta.env.ELECTRON) {
@@ -14,6 +16,10 @@ const root = createRoot(document.getElementById("root")!);
 
 root.render(
   <StrictMode>
-    <App />
+    <LanguageProvider>
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </LanguageProvider>
   </StrictMode>
 );

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useLanguage } from '@/lib/i18n/translations.ts';
+import { useSettings } from '@/hooks/use-settings';
 import {
   Card,
   CardContent,
@@ -27,9 +28,10 @@ import { Button } from '@/components/ui/button';
 import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon } from 'lucide-react';
 
 const SettingsPage: React.FC = () => {
-  const { t, language, setLanguage } = useLanguage();
+  const { t } = useLanguage();
   const { toast } = useToast();
-  const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
+  const { settings, setTheme, setLanguage } = useSettings();
+  const { theme, language } = settings;
   const [emailNotifications, setEmailNotifications] = React.useState(true);
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
@@ -44,25 +46,14 @@ const SettingsPage: React.FC = () => {
   };
 
   const handleThemeChange = (value: 'light' | 'dark' | 'system') => {
-    setTheme(value);
-    // Apply theme change logic here
-    document.documentElement.classList.remove('light', 'dark');
-    if (value === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-      document.documentElement.classList.add(systemTheme);
-    } else {
-      document.documentElement.classList.add(value);
-    }
-    
+    setTheme(value as 'light' | 'dark' | 'system');
     toast({
       title: t('settings.changesApplied'),
-      description: t('settings.theme') + ': ' + 
-        (value === 'light' 
-          ? t('settings.lightMode') 
-          : value === 'dark' 
-            ? t('settings.darkMode') 
+      description: t('settings.theme') + ': ' +
+        (value === 'light'
+          ? t('settings.lightMode')
+          : value === 'dark'
+            ? t('settings.darkMode')
             : t('settings.system')),
       duration: 2000,
     });


### PR DESCRIPTION
## Summary
- store user-selected theme and language in localStorage
- apply settings on startup via `SettingsProvider`
- persist theme early in `index.html`
- wrap app with new provider
- use persisted settings in the settings page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*