### PR TITLE
Implement persisted settings provider

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,20 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script>
+    (function() {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme) {
+          document.documentElement.classList.remove('light','dark');
+          if (theme === 'system') {
+            theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          document.documentElement.classList.add(theme);
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/client/src/components/language-switcher.tsx
+++ b/client/src/components/language-switcher.tsx
@@ -8,19 +8,20 @@ import {
 import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
 import i18n from '../i18n';
+import { useSettings } from '@/context/SettingsContext';
 
 export function LanguageSwitcher() {
-  const currentLanguage = i18n.language;
+  const { language, setLanguage } = useSettings();
 
   const handleLanguageChange = async (value: string) => {
-    await i18n.changeLanguage(value);
+    await setLanguage(value);
   };
 
   return (
     <div className="flex flex-col space-y-2">
       <Label htmlFor="language-select">{i18n.t('settings.general')}</Label>
       <Select
-        value={currentLanguage}
+        value={language}
         onValueChange={handleLanguageChange}
       >
         <SelectTrigger id="language-select" className="w-[180px]">

--- a/client/src/context/SettingsContext.tsx
+++ b/client/src/context/SettingsContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import i18n from '@/i18n';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+interface SettingsContextType {
+  theme: Theme;
+  language: string;
+  setTheme: (theme: Theme) => void;
+  setLanguage: (lang: string) => Promise<void>;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.remove('light', 'dark');
+  if (theme === 'system') {
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    document.documentElement.classList.add(systemTheme);
+  } else {
+    document.documentElement.classList.add(theme);
+  }
+}
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('system');
+  const [language, setLanguageState] = useState<string>(i18n.language || 'en');
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme') as Theme | null;
+    const storedLang = localStorage.getItem('language');
+    if (storedTheme) {
+      setThemeState(storedTheme);
+      applyTheme(storedTheme);
+    }
+    if (storedLang) {
+      setLanguageState(storedLang);
+      i18n.changeLanguage(storedLang).catch(console.error);
+    }
+  }, []);
+
+  const setTheme = (value: Theme) => {
+    setThemeState(value);
+    localStorage.setItem('theme', value);
+    applyTheme(value);
+  };
+
+  const setLanguage = async (lang: string) => {
+    setLanguageState(lang);
+    localStorage.setItem('language', lang);
+    await i18n.changeLanguage(lang);
+  };
+
+  return (
+    <SettingsContext.Provider value={{ theme, language, setTheme, setLanguage }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within a SettingsProvider');
+  return ctx;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -14,10 +14,13 @@ import util from 'util';
 import { StrictMode } from 'react';
 import { createRoot }  from 'react-dom/client';
 import App             from './App';
+import { SettingsProvider } from './context/SettingsContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </StrictMode>,
 );

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslations } from '@/hooks/use-translations';
+import { useSettings } from '@/context/SettingsContext';
 import {
   Card,
   CardContent,
@@ -27,25 +28,15 @@ import { Button } from '@/components/ui/button';
 import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon } from 'lucide-react';
 
 const SettingsPage: React.FC = () => {
-  const { t, currentLanguage, changeLanguage } = useTranslations();
+  const { t } = useTranslations();
+  const { theme, setTheme, language, setLanguage } = useSettings();
   const { toast } = useToast();
-  const [theme, setTheme] = React.useState<'light' | 'dark' | 'system'>('system');
   const [emailNotifications, setEmailNotifications] = React.useState(true);
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
 
   const handleThemeChange = (value: 'light' | 'dark' | 'system') => {
     setTheme(value);
-    // Apply theme change logic here
-    document.documentElement.classList.remove('light', 'dark');
-    if (value === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-      document.documentElement.classList.add(systemTheme);
-    } else {
-      document.documentElement.classList.add(value);
-    }
     
     toast({
       title: t('settings.changesApplied'),
@@ -161,8 +152,8 @@ const SettingsPage: React.FC = () => {
                 <div className="space-y-2">
                   <Label htmlFor="language">{t('settings.language')}</Label>
                   <Select
-                    value={currentLanguage}
-                    onValueChange={changeLanguage}
+                    value={language}
+                    onValueChange={setLanguage}
                   >
                     <SelectTrigger id="language" className="flex items-center gap-2">
                       <Globe className="h-4 w-4" />

--- a/client/src/pages/settings-section.tsx
+++ b/client/src/pages/settings-section.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "../hooks/use-auth";
 import { useTranslations } from "@/hooks/use-translations";
+import { useSettings } from "@/context/SettingsContext";
 import {
   Select,
   SelectTrigger,
@@ -11,7 +12,8 @@ import { Label } from "@/components/ui/label";
 
 export default function SettingsSection() {
   const { user } = useAuth();
-  const { t, currentLanguage, changeLanguage } = useTranslations();
+  const { t } = useTranslations();
+  const { language, setLanguage } = useSettings();
 
   if (!user) return null;
 
@@ -20,7 +22,7 @@ export default function SettingsSection() {
       <h2 className="text-xl font-semibold mb-4">{t('settings.title')}</h2>
       <div className="space-y-2 max-w-xs">
         <Label htmlFor="language">{t('settings.language')}</Label>
-        <Select value={currentLanguage} onValueChange={changeLanguage}>
+        <Select value={language} onValueChange={setLanguage}>
           <SelectTrigger id="language">
             <SelectValue placeholder={t('settings.language')} />
           </SelectTrigger>


### PR DESCRIPTION
## Summary
- add new `SettingsContext` provider to store theme and language
- load saved theme and language in provider
- apply stored theme early from `index.html`
- wrap application with `SettingsProvider`
- update settings pages and language switcher to use the provider

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*