### PR TITLE
Add custom Electron window controls

### DIFF
--- a/client/src/components/ui/window-frame.tsx
+++ b/client/src/components/ui/window-frame.tsx
@@ -1,9 +1,11 @@
-import { X, Minimize, Maximize } from 'lucide-react';
+import { X, Minimize, Maximize, RotateCw, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useElectron } from '@/hooks/use-electron';
+import { useAuth } from '@/hooks/use-auth';
 export const WindowFrame = () => {
   const { isElectron, api } = useElectron();
-    if (!isElectron) return null;
+  const { user } = useAuth();
+  if (!isElectron) return null;
   
   const handleMinimize = () => {
     api?.app?.minimize();
@@ -15,6 +17,14 @@ export const WindowFrame = () => {
 
   const handleClose = () => {
     api?.app?.quit();
+  };
+
+  const handleReload = () => {
+    api?.app?.reload();
+  };
+
+  const handleDevTools = () => {
+    api?.app?.openDevTools();
   };
   
 
@@ -36,6 +46,24 @@ export const WindowFrame = () => {
       >
         <Maximize className="h-4 w-4" />
       </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 rounded-md"
+        onClick={handleReload}
+      >
+        <RotateCw className="h-4 w-4" />
+      </Button>
+      {user?.isAdmin && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 rounded-md"
+          onClick={handleDevTools}
+        >
+          <Terminal className="h-4 w-4" />
+        </Button>
+      )}
       <Button
         variant="ghost"
         size="icon"

--- a/client/src/lib/electron-types.ts
+++ b/client/src/lib/electron-types.ts
@@ -13,6 +13,8 @@ export interface ElectronAPI {
     quit: () => Promise<void>;
     minimize: () => Promise<void>;
     maximize: () => Promise<void>;
+    reload: () => Promise<void>;
+    openDevTools: () => Promise<void>;
   };
   // System utilities
   system: {

--- a/client/src/lib/web-polyfills.ts
+++ b/client/src/lib/web-polyfills.ts
@@ -187,6 +187,8 @@ function createMockElectronAPI(): ElectronAPI {
       quit: () => Promise.resolve(),
       minimize: () => Promise.resolve(),
       maximize: () => Promise.resolve(),
+      reload: () => Promise.resolve(),
+      openDevTools: () => Promise.resolve(),
     },
     system: {
       getSystemInfo: () => Promise.resolve({

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -57,6 +57,8 @@ async function createWindow() {
       mainWindow?.maximize();
     }
   });
+  ipcMain.handle('window-reload', () => mainWindow?.reload());
+  ipcMain.handle('open-devtools', () => mainWindow?.webContents.openDevTools());
   ipcMain.handle('app-quit',    () => { app.quit(); });
   ipcMain.handle('window-close', () => mainWindow?.hide());
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,6 +11,8 @@ contextBridge.exposeInMainWorld("electron", {
     minimize:    () => ipcRenderer.invoke("window-minimize"),
     maximize:    () => ipcRenderer.invoke("window-maximize"),
     quit:        () => ipcRenderer.invoke("app-quit"),
+    reload:      () => ipcRenderer.invoke("window-reload"),
+    openDevTools: () => ipcRenderer.invoke("open-devtools"),
   },
   window: {    close: () => ipcRenderer.invoke("window-close"),
   },


### PR DESCRIPTION
## Summary
- expose reload and openDevTools in Electron preload
- add IPC handlers in Electron main
- extend Electron API typings and web polyfill
- show reload and devtools buttons in window frame

## Testing
- `npx tsc -p client/tsconfig.json -noEmit` *(fails: Cannot find type definition file for 'node')*