### PR TITLE
Add reload and devtools controls

### DIFF
--- a/build/client/src/lib/web-polyfills.js
+++ b/build/client/src/lib/web-polyfills.js
@@ -169,6 +169,11 @@ function createMockElectronAPI() {
             quit: () => Promise.resolve(),
             minimize: () => Promise.resolve(),
             maximize: () => Promise.resolve(),
+            reload: () => {
+                window.location.reload();
+                return Promise.resolve();
+            },
+            openDevTools: () => Promise.resolve(),
         },
         system: {
             getSystemInfo: () => Promise.resolve({

--- a/client/src/components/ui/window-frame.tsx
+++ b/client/src/components/ui/window-frame.tsx
@@ -1,4 +1,4 @@
-import { X, Minimize, Maximize, RefreshCw, LogOut } from 'lucide-react';
+import { X, Minimize, Maximize, RefreshCw, LogOut, Bug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useElectron } from '@/hooks/use-electron';
 import { useAuth } from '@/hooks/use-auth';
@@ -10,7 +10,8 @@ export const WindowFrame = () => {
   const handleMinimize = () => api?.app?.minimize?.() ?? window.scrollTo({ top: 0, behavior: 'smooth' });
   const handleMaximize = () => api?.app?.maximize?.() ?? window.open(window.location.href, '_blank');
   const handleClose = () => api?.app?.quit?.() ?? window.close();
-  const handleRefresh = () => window.location.reload();
+  const handleRefresh = () => api?.app?.reload?.() ?? window.location.reload();
+  const handleDevTools = () => api?.app?.openDevTools?.();
   const handleLogout = () => logout();
 
   return (
@@ -20,6 +21,9 @@ export const WindowFrame = () => {
       </Button>
       {isElectron && (
         <>
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={handleDevTools}>
+            <Bug className="h-4 w-4"/>
+          </Button>
           <Button variant="ghost" size="icon" className="h-7 w-7" onClick={handleMinimize}>
             <Minimize className="h-4 w-4"/>
           </Button>

--- a/client/src/lib/electron-types.ts
+++ b/client/src/lib/electron-types.ts
@@ -28,6 +28,8 @@ export interface ElectronAPI {
     quit: () => Promise<void>;
     minimize: () => Promise<void>;
     maximize: () => Promise<void>;
+    reload: () => Promise<void>;
+    openDevTools: () => Promise<void>;
   };
 
   // File system operations

--- a/client/src/lib/web-polyfills.ts
+++ b/client/src/lib/web-polyfills.ts
@@ -187,6 +187,11 @@ function createMockElectronAPI(): ElectronAPI {
       quit: () => Promise.resolve(),
       minimize: () => Promise.resolve(),
       maximize: () => Promise.resolve(),
+      reload: () => {
+        window.location.reload();
+        return Promise.resolve();
+      },
+      openDevTools: () => Promise.resolve(),
     },
     system: {
       getSystemInfo: () => Promise.resolve({

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -44,6 +44,14 @@ ipcMain.on('ping', (event: IpcMainEvent, msg: any) => {
   event.reply('pong', '🤖');
 });
 
+ipcMain.handle('window-reload', () => {
+  mainWindow?.reload();
+});
+
+ipcMain.handle('open-devtools', () => {
+  mainWindow?.webContents.openDevTools();
+});
+
 app.whenReady().then(createMainWindow);
 
 // macOS / общего назначения обработчики

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -7,6 +7,8 @@ contextBridge.exposeInMainWorld('electron', {
     quit: () => ipcRenderer.invoke('app-quit'),
     minimize: () => ipcRenderer.invoke('window-minimize'),
     maximize: () => ipcRenderer.invoke('window-maximize'),
+    reload: () => ipcRenderer.invoke('window-reload'),
+    openDevTools: () => ipcRenderer.invoke('open-devtools'),
   },
   system: {
     getSystemInfo: () => ipcRenderer.invoke('get-system-info'),


### PR DESCRIPTION
## Summary
- expose `reload` and `openDevTools` in the preload script
- add IPC handlers for reloading and opening devtools
- extend `ElectronAPI` typings and polyfills
- show reload and devtools buttons in the window frame

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*