### PR TITLE
Implement wiki article viewer and editing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from 'react-hot-toast';
 import AuthPage from './pages/auth-page';
 import HomePage from "./pages/home-page";
 import SettingsPage from './pages/settings-page';
+import WikiArticlePage from './pages/wiki-article-page';
 import { Route, Switch, Redirect } from 'wouter';
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "./hooks/use-auth";
@@ -35,6 +36,9 @@ function AppContent() {
           </Route>
           <Route path="/settings">
             {user ? <SettingsPage /> : <Redirect to="/auth" />}
+          </Route>
+          <Route path="/wiki/:id">
+            {user ? <WikiArticlePage /> : <Redirect to="/auth" />}
           </Route>
           <Route>
             {user ? <HomePage /> : <Redirect to="/auth" />}

--- a/client/src/api/wiki.ts
+++ b/client/src/api/wiki.ts
@@ -14,6 +14,10 @@ export async function getWikiCategories(): Promise<WikiCategory[]> {
   return (await apiClient.request<WikiCategory[]>('/api/wiki/categories')) ?? [];
 }
 
+export async function getWikiEntry(id: number): Promise<WikiEntry | undefined> {
+  return apiClient.request<WikiEntry>(`/api/wiki/entries/${id}`);
+}
+
 export async function createWikiEntry(
   data: InsertWikiEntry
 ): Promise<WikiEntry> {
@@ -25,4 +29,14 @@ export async function createWikiEntry(
     throw new Error('createWikiEntry: no entry returned from server');
   }
   return entry;
+}
+
+export async function updateWikiEntry(
+  id: number,
+  patch: Partial<InsertWikiEntry>
+): Promise<WikiEntry | undefined> {
+  return apiClient.request<WikiEntry>(`/api/wiki/entries/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  });
 }

--- a/client/src/pages/wiki-article-page.tsx
+++ b/client/src/pages/wiki-article-page.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useRoute } from 'wouter';
+import ReactMarkdown from 'react-markdown';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { createApiClient } from '@/lib/api-client';
+import { useAuth } from '@/hooks/use-auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { DialogFooter } from '@/components/ui/dialog';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowLeft, Edit, Loader2 } from 'lucide-react';
+import { getWikiEntry, updateWikiEntry } from '../api/wiki';
+import { useToast } from '@/hooks/use-toast';
+
+const entrySchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  content: z.string().min(1, 'Content is required'),
+  category: z.string().optional(),
+});
+
+type EntryValues = z.infer<typeof entrySchema>;
+
+export default function WikiArticlePage() {
+  const [, params] = useRoute<{ id: string }>('/wiki/:id');
+  const id = Number(params?.id);
+  const [, setLocation] = useLocation();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const apiClient = createApiClient();
+
+  const { data: entry, isLoading, refetch } = useQuery({
+    queryKey: ['/api/wiki/entries', id],
+    enabled: !!id,
+    queryFn: () => getWikiEntry(id),
+  });
+
+  const form = useForm<EntryValues>({
+    resolver: zodResolver(entrySchema),
+    defaultValues: { title: '', content: '', category: '' },
+  });
+
+  useEffect(() => {
+    if (entry) {
+      form.reset({
+        title: entry.title,
+        content: entry.content,
+        category: entry.category || '',
+      });
+    }
+  }, [entry, form]);
+
+  const updateMutation = useMutation({
+    mutationFn: (values: EntryValues) =>
+      updateWikiEntry(id, {
+        title: values.title,
+        content: values.content,
+        category: values.category,
+        lastEditorId: user?.id,
+        updatedAt: new Date().toISOString(),
+      }),
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Wiki entry updated' });
+      refetch();
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to update entry', variant: 'destructive' });
+    },
+  });
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const onSubmit = (values: EntryValues) => {
+    updateMutation.mutate(values);
+    setIsEditing(false);
+  };
+
+  if (isLoading || !entry) {
+    return (
+      <div className="p-4 flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 w-full">
+      <Button variant="ghost" size="icon" onClick={() => setLocation('/')}
+        className="mb-4">
+        <ArrowLeft className="h-5 w-5" />
+      </Button>
+
+      {isEditing ? (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="content"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Content</FormLabel>
+                  <FormControl>
+                    <Textarea className="min-h-[300px]" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setIsEditing(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={updateMutation.isPending}>
+                {updateMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      ) : (
+        <>
+          <div className="flex justify-between items-center mb-4">
+            <h1 className="text-3xl font-bold">{entry.title}</h1>
+            {user?.isAdmin === 1 && (
+              <Button size="sm" onClick={() => setIsEditing(true)}>
+                <Edit className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+            )}
+          </div>
+          <div className="prose max-w-none">
+            <ReactMarkdown>{entry.content}</ReactMarkdown>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -19,6 +19,7 @@ import type { WikiEntry, WikiCategory } from '@shared/schema/wiki';
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
 import { Loader2, PlusCircle, Search, ChevronRight, Edit, Trash2 } from "lucide-react";
+import { useLocation } from "wouter";
 import ReactMarkdown from 'react-markdown';
 
 
@@ -44,6 +45,7 @@ export default function WikiSection() {
   const { request } = apiClient;
   const { user } = useAuth();
   const { toast } = useToast();
+  const [, setLocation] = useLocation();
   const [activeTab, setActiveTab] = useState("entries");
   const [searchQuery, setSearchQuery] = useState("");
   const [showEntryDialog, setShowEntryDialog] = useState(false);
@@ -483,12 +485,16 @@ export default function WikiSection() {
               <ScrollArea className="h-full">
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {filteredEntries.map((entry: WikiEntry) => (
-                    <Card key={entry.id} className="h-full">
+                    <Card
+                      key={entry.id}
+                      className="h-full cursor-pointer"
+                      onClick={() => setLocation(`/wiki/${entry.id}`)}
+                    >
                       <CardHeader className="pb-2">
                         <div className="flex justify-between items-start">
                           <CardTitle className="text-xl">{entry.title}</CardTitle>
                           {user?.isAdmin && (
-                            <div className="flex space-x-1">
+                            <div className="flex space-x-1" onClick={e => e.stopPropagation()}>
                               <Button size="icon" variant="ghost" onClick={() => handleEditEntry(entry)}>
                                 <Edit className="h-4 w-4" />
                               </Button>

--- a/server/src/routes/wiki.ts
+++ b/server/src/routes/wiki.ts
@@ -12,6 +12,16 @@ router.get('/entries', async (req, res) => {
   res.json(rows);
 });
 
+// GET /api/wiki/entries/:id – получить одну запись
+router.get('/entries/:id', async (req, res) => {
+  const entryId = +req.params.id;
+  const { rows } = await db!.query('SELECT * FROM wiki_entries WHERE id = $1', [entryId]);
+  if (rows.length === 0) {
+    return res.status(404).json({ error: 'Entry not found' });
+  }
+  res.json(rows[0]);
+});
+
 // GET /api/wiki/categories – список категорий
 router.get('/categories', async (req, res) => {
   const { rows } = await db!.query('SELECT * FROM wiki_categories');


### PR DESCRIPTION
## Summary
- add endpoint to fetch single wiki entry
- provide client helpers to fetch/update entries
- make wiki list entries open viewer on click
- allow editing wiki article in new page
- route `/wiki/:id` to display a full article

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*