### PR TITLE
Fix wiki admin button visibility

### DIFF
--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -427,7 +427,7 @@ export default function WikiSection() {
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Employee Wiki</h1>
         <div className="flex space-x-2">
-          {user?.isAdmin === 1 && (
+          {user?.isAdmin && (
             <>          
               <Button onClick={handleAddEntry} size="sm">
                 <PlusCircle className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- show wiki edit buttons whenever `user.isAdmin` is truthy

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm ci --ignore-scripts` *(fails: Exit handler never called)*