### PR TITLE
Improve message bubble styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,5 @@
 - **API**: The `/api/departments` endpoint should return a list of departments for the request modal.
 Feel free to add new things to the guidelines. This may be your nothes on the project.
 
+Note: Message bubbles use a lighter primary color for sent messages on the right and a darker gray for received messages on the left.
+

--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -37,10 +37,10 @@ export function MessageList({ messages, myId }: MessageListProps) {
       {messages.map((m) => (
         <div
           key={m.id}
-          className={`max-w-[80%] rounded-lg px-4 py-2 text-sm break-words ${
+          className={`max-w-[80%] rounded-xl px-4 py-2 text-sm break-words ${
             m.senderId === myId
-              ? 'ml-auto bg-primary-600 text-white'
-              : 'mr-auto bg-gray-100 dark:bg-gray-800'
+              ? 'ml-auto bg-primary-100 text-primary-900 dark:bg-primary-700 dark:text-white'
+              : 'mr-auto bg-gray-200 text-black dark:bg-gray-700 dark:text-white'
           }`}
         >
           {m.content}


### PR DESCRIPTION
## Summary
- lighten the background for sent messages and darken received messages
- document message bubble colors in AGENTS notes

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*