### PR TITLE
Fix P2P reconnects and track online status

### DIFF
--- a/client/src/hooks/usePeerConnection.ts
+++ b/client/src/hooks/usePeerConnection.ts
@@ -13,13 +13,17 @@ export interface PeerMessage {
 export function usePeerConnection(
   initiator: boolean,
   onSignal: (signal: SimplePeer.SignalData) => void,
-  incomingSignal?: SimplePeer.SignalData
+  incomingSignal?: SimplePeer.SignalData,
+  enabled = true,
 ) {
   const [status, setStatus] = useState<PeerStatus>('init');
   const [lastMessage, setLastMessage] = useState<PeerMessage | null>(null);
   const peerRef = useRef<Peer>();
+  const onSignalRef = useRef(onSignal);
+  onSignalRef.current = onSignal;
 
   useEffect(() => {
+    if (!enabled) return;
     console.debug('P2P creating connection', { initiator });
     const peer = new SimplePeer({
       initiator,
@@ -29,7 +33,7 @@ export function usePeerConnection(
 
     peer.on('signal', (sig) => {
       console.debug('P2P signal', sig);
-      onSignal(sig);
+      onSignalRef.current(sig);
     });
 
     if (incomingSignal) {
@@ -62,11 +66,13 @@ export function usePeerConnection(
     peerRef.current = peer;
     setStatus('connecting');
 
-    return () => peer.destroy();
-  }, [initiator, onSignal, incomingSignal]);
+    return () => {
+      peer.destroy();
+    };
+  }, [enabled, initiator, incomingSignal]);
 
   const send = (msg: PeerMessage) => {
-    if (peerRef.current?.connected) {
+    if (enabled && peerRef.current?.connected) {
       console.debug('P2P send', msg);
       peerRef.current.send(JSON.stringify(msg));
     }

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/use-auth';
 import { useChat } from '@/context/ChatContext';
@@ -124,12 +124,16 @@ export default function MessagesSection({ onStartCall }: Props) {
     send: sendP2P,
   } = usePeerConnection(
     isInitiator,
-    (signal) =>
-      sendRaw({
-        type: 'p2p-signal',
-        payload: { to: selectedUser!.id, signal },
-      }),
+    useCallback(
+      (signal: any) =>
+        sendRaw({
+          type: 'p2p-signal',
+          payload: { to: selectedUser!.id, signal },
+        }),
+      [sendRaw, selectedUser]
+    ),
     incomingSignal,
+    !!selectedUser && selectedUser.isonline === 1,
   );
 
   /* ───── WS side‑effects ───── */

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -39,6 +39,8 @@ router.post('/login', async (req: Request, res: Response) => {
     await new Promise<void>((resolve, reject) =>
       req.session.save(err => (err ? reject(err) : resolve()))
     );
+    await db!.query('UPDATE users SET isonline = 1 WHERE id = $1', [user.id]);
+    broadcastStatus(user.id, 1);
     res.json(user);
   } catch (err) {
     logger.error('Login error:', err);
@@ -60,6 +62,8 @@ router.post('/register', async (req: Request, res: Response) => {
     await new Promise<void>((resolve, reject) =>
       req.session.save(err => (err ? reject(err) : resolve()))
     );
+    await db!.query('UPDATE users SET isonline = 1 WHERE id = $1', [newUser.id]);
+    broadcastStatus(newUser.id, 1);
     res.status(201).json(newUser);
   } catch (err) {
     logger.error('Register error:', err);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { login, register } from '../lib/api/auth';
+import { db } from '../db';
+import { broadcastStatus } from '../ws';
 import { logger } from '@shared/logger';
 
 
@@ -19,6 +21,8 @@ router.post('/login', async (req: Request, res: Response) => {
       await new Promise<void>((resolve, reject) =>
         req.session.save(err => err ? reject(err) : resolve())
       );
+      await db!.query('UPDATE users SET isonline = 1 WHERE id = $1', [user.id]);
+      broadcastStatus(user.id, 1);
       res.json({ id: user.id });
     } catch (error) {
       logger.error('Login error:', error);
@@ -36,6 +40,8 @@ router.post('/register', async (req: Request, res: Response) => {
      await new Promise<void>((resolve, reject) =>
        req.session.save(err => err ? reject(err) : resolve())
      );
+     await db!.query('UPDATE users SET isonline = 1 WHERE id = $1', [newUser.id]);
+     broadcastStatus(newUser.id, 1);
      res.json({ id: newUser.id });
    } catch (error) {
      logger.error('Register failed:', error);
@@ -48,6 +54,12 @@ router.post('/logout', (req: Request, res: Response) => {
     if (err) {
       logger.error('Logout error:', err);
       return res.status(500).json({ error: 'Logout failed' });
+    }
+    const userId = (req.session as any).userId as number | undefined;
+    if (userId) {
+      db!.query('UPDATE users SET isonline = 0 WHERE id = $1', [userId])
+        .then(() => broadcastStatus(userId, 0))
+        .catch((e) => logger.error('Set offline failed:', e));
     }
     res.clearCookie('connect.sid');
     res.json({ success: true });

--- a/server/src/ws.ts
+++ b/server/src/ws.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage } from 'http';
 import type { RequestHandler } from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
 import { logger } from './util/logger';
+import { db } from './db';
 
 // Сервер + карта подключений userId → ws
 let wss: WebSocketServer;
@@ -45,6 +46,9 @@ export function initWebSocket(
     logger.info(
       `🟢 WS connected: user ${userId} from ${req.socket.remoteAddress ?? 'unknown'}`
     );
+    db!.query('UPDATE users SET isonline = 1 WHERE id = $1', [userId])
+      .then(() => broadcastStatus(userId, 1))
+      .catch((e) => logger.error('Set online failed:', e));
 
     // Обработка входящих P2P-сигналов
     ws.on('message', (data) => {
@@ -78,6 +82,9 @@ export function initWebSocket(
       logger.info(
         `🔴 WS disconnected: user ${userId} code=${code} reason=${reason.toString()}`
       );
+      db!.query('UPDATE users SET isonline = 0 WHERE id = $1', [userId])
+        .then(() => broadcastStatus(userId, 0))
+        .catch((e) => logger.error('Set offline failed:', e));
     });
 
     ws.on('error', (err) => {


### PR DESCRIPTION
## Summary
- update websocket events to mark users online/offline
- set `isonline` during login/register/logout
- add `enabled` flag to peer connection hook to avoid repeated reconnections
- only create peer connection when chat partner is online

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*