### PR TITLE
Reduce pino-http logs

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -16,7 +16,7 @@ export async function createApp() {
   app.use(express.json());
 
   // HTTP logging middleware
-  app.use(pinoHttp({ logger }));
+  app.use(pinoHttp({ logger, autoLogging: false }));
 
   // debug middleware
   app.use((req, _res, next) => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -31,7 +31,7 @@ export function createApp(): Express {
   app.set('session-middleware', sess as RequestHandler); 
 
   /* ───────── COMMON MIDDLEWARE ───────── */
-  app.use(pinoHttp({ logger: logger as any }));
+  app.use(pinoHttp({ logger: logger as any, autoLogging: false }));
   app.use(morgan('dev'));
   app.use(express.json());
   app.use(


### PR DESCRIPTION
## Summary
- disable autoLogging in pino-http middleware to trim request logging

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*