### PR TITLE
Fix breadcrumb generation when parentId is null

### DIFF
--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -119,13 +119,13 @@ export default function WikiSection() {
     }
 
     const crumbs: WikiCategory[] = [];
-    let currentCategoryId = activeCategoryId;
+    let currentCategoryId: number | null = activeCategoryId;
 
-    while (currentCategoryId) {
+    while (currentCategoryId !== null) {
       const category = categories.find((c) => c.id === currentCategoryId);
       if (!category) break;
       crumbs.unshift(category);
-      currentCategoryId = category.parentId ?? null;
+      currentCategoryId = category.parentId;
     }
 
     return crumbs;


### PR DESCRIPTION
## Summary
- fix breadcrumb loop in `wiki-section` to handle null parent category IDs

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*