### PR TITLE
Fix user typings

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -26,6 +26,7 @@ export interface UserWithoutPassword {
   email: string | null;
   firstName: string | null;
   lastName: string | null;
+  jobTitle?: string | null;
   isAdmin?: number;
   isOnline: boolean | number;
   avatarUrl: string | null;

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -33,7 +33,7 @@ import { MessageList } from '@/components/message-list';
 export interface Message {
   id: number;
   senderId: number;
-  receiverId?: number;
+  receiverId: number;
   content: string;
   timestamp: string;
   file?: string;

--- a/client/src/pages/wiki-article-page.tsx
+++ b/client/src/pages/wiki-article-page.tsx
@@ -60,7 +60,7 @@ export default function WikiArticlePage() {
         content: values.content,
         category: values.category,
         lastEditorId: user?.id,
-        updatedAt: new Date().toISOString(),
+        updatedAt: new Date(),
       }),
     onSuccess: () => {
       toast({ title: 'Success', description: 'Wiki entry updated' });

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -6,6 +6,7 @@ export interface UserWithoutPassword {
   phone?: string;
   firstName: string | null;
   lastName: string | null;
+  jobTitle?: string | null;
   isOnline: boolean | number;
   avatarUrl: string | null;
 }

--- a/shared/electron-shared/types.ts
+++ b/shared/electron-shared/types.ts
@@ -4,5 +4,7 @@ export interface UserWithoutPassword {
   lastName: string | null;
   email: string;
   phone?: string;
+  jobTitle?: string | null;
+  isonline?: number | boolean;
   isAdmin?: number;   // 0 | 1
 }

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -8,10 +8,12 @@ import { z } from "zod";
 export interface User {
   id: number;
   firstName: string;
-  lastName: string; 
+  lastName: string;
   username: string;
   email: string;
   avatarUrl?: string | null;
+  jobTitle?: string | null;
+  isonline?: number | boolean;
 }
 
 export interface Group {

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -5,6 +5,8 @@ export interface UserWithoutPassword {
   firstName?: string;
   lastName?: string;
   phone?: string;
+  jobTitle?: string | null;
+  isonline?: number | boolean;
   isAdmin?: number;
 }
 


### PR DESCRIPTION
## Summary
- extend shared user schema with `jobTitle` and `isonline`
- expose jobTitle in frontend auth types
- require receiverId in message interface
- use Date object in Wiki article update

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*