### PR TITLE
Fix user online status reset

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -27,4 +27,17 @@ export async function connectDb(): Promise<void> {
   }
 }
 
+export async function resetAllOnlineStatus(): Promise<void> {
+  if (!pgClient) {
+    throw new Error('Database not connected');
+  }
+  try {
+    await pgClient.query('UPDATE users SET isonline = 0');
+    logger.info('All user statuses reset to offline');
+  } catch (err) {
+    logger.error('Failed to reset user statuses:', err);
+    throw err;
+  }
+}
+
 export { pgClient as db };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,7 +3,7 @@ import "./config/env";
 import * as http from "http";
 import express, { RequestHandler } from "express";
 import { createApp } from "./app";
-import { connectDb } from "./db";
+import { connectDb, resetAllOnlineStatus } from "./db";
 import { config } from "./config/env";
 import { logger } from "./util/logger";
 import session from "express-session";
@@ -11,6 +11,7 @@ import { initWebSocket } from "./ws";
 
 async function main() {
   await connectDb();
+  await resetAllOnlineStatus();
 
   const app = createApp();
 


### PR DESCRIPTION
## Summary
- reset all users to offline when the server starts

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog', etc.)*