### PR TITLE
Fix wiki admin permissions and add markdown editor

### DIFF
--- a/client/src/components/markdown-editor.tsx
+++ b/client/src/components/markdown-editor.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function escapeHtml(html: string) {
+  return html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function renderMarkdown(md: string): string {
+  let html = escapeHtml(md);
+  html = html.replace(/^### (.*)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^## (.*)$/gm, "<h2>$1</h2>");
+  html = html.replace(/^# (.*)$/gm, "<h1>$1</h1>");
+  html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*(.*?)\*/g, "<em>$1</em>");
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\n/g, "<br />");
+  return html;
+}
+
+export default function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
+  const [tab, setTab] = useState("write");
+
+  return (
+    <Tabs value={tab} onValueChange={setTab} className="h-full flex flex-col">
+      <TabsList className="grid w-40 grid-cols-2">
+        <TabsTrigger value="write">Write</TabsTrigger>
+        <TabsTrigger value="preview">Preview</TabsTrigger>
+      </TabsList>
+      <TabsContent value="write" className="flex-1 mt-2">
+        <Textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-full"
+        />
+      </TabsContent>
+      <TabsContent value="preview" className="flex-1 mt-2 overflow-auto">
+        <ScrollArea className="h-full">
+          <div
+            className="prose max-w-none"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(value) }}
+          />
+        </ScrollArea>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -5,6 +5,14 @@ import { useLocation } from "wouter";
 import { getQueryFn, createApiClient, queryClient } from "../lib/queryClient";
 import { useTranslations } from "./use-translations";
 
+function normalizeUser(user: any) {
+  if (!user) return user;
+  if (user.isAdmin === undefined && user.is_admin !== undefined) {
+    user.isAdmin = user.is_admin ? 1 : 0;
+  }
+  return user;
+}
+
 
 export type User = {
   id: number;
@@ -78,7 +86,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     Error
   >({
     queryKey: ["/api/user"],
-    queryFn: getQueryFn("/api/user"),
+    queryFn: async () => {
+      const data = await getQueryFn<UserWithoutPassword | null>("/api/user")();
+      return normalizeUser(data);
+    },
   });
 
   const loginMutation = useMutation({
@@ -91,7 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         body: JSON.stringify(credentials),
       });
       const user = await res.json();
-      return user;
+      return normalizeUser(user);
     },
     
   });
@@ -125,7 +136,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   return (
     <AuthContext.Provider
     value={{
-      user: user || null,
+      user: normalizeUser(user) || null,
       isLoading,
       error: authError,
       login,

--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import MarkdownEditor from "../components/markdown-editor";
 import { useToast } from "@/hooks/use-toast";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -427,7 +428,7 @@ export default function WikiSection() {
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Employee Wiki</h1>
         <div className="flex space-x-2">
-          {user?.isAdmin === 1 && (
+          {user?.isAdmin && (
             <>          
               <Button onClick={handleAddEntry} size="sm">
                 <PlusCircle className="h-4 w-4 mr-2" />
@@ -681,10 +682,9 @@ export default function WikiSection() {
                   <FormItem>
                     <FormLabel>Content</FormLabel>
                     <FormControl>
-                      <Textarea
-                        placeholder="Write the content here..."
-                        className="min-h-[250px]"
-                        {...field}
+                      <MarkdownEditor
+                        value={field.value}
+                        onChange={field.onChange}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
## Summary
- handle `is_admin` flag in `use-auth`
- enable admin wiki buttons regardless of numeric value
- provide simple markdown editor for wiki entries

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*