### PR TITLE
Add toast notification for incoming messages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { Route, Switch, Redirect } from 'wouter';
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "./hooks/use-auth";
 import { ChatProvider } from "./context/ChatContext";
+import { WebSocketProvider } from "./context/WebSocketContext";
 import { WindowFrameHeader } from "./components/ui/window-frame";
 import { useElectron } from "./hooks/use-electron";
 import { useEffect, useState } from "react";
@@ -77,13 +78,15 @@ export default function App() {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <ChatProvider>
-          <AppContent />
-          {status !== 'ok' && (
-            <div>
-              <h1>Server Status: {status}</h1>
-              <p>{message}</p>
-            </div>
-          )}
+          <WebSocketProvider>
+            <AppContent />
+            {status !== 'ok' && (
+              <div>
+                <h1>Server Status: {status}</h1>
+                <p>{message}</p>
+              </div>
+            )}
+          </WebSocketProvider>
         </ChatProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/client/src/context/WebSocketContext.tsx
+++ b/client/src/context/WebSocketContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, ReactNode } from 'react';
+import { useWebSocket, ConnectionStatus, WSMessage } from '@/hooks/useWebSocket';
+
+interface WSContextValue {
+  connectionStatus: ConnectionStatus;
+  lastRawMessage: WSMessage | null;
+  sendRaw: (msg: WSMessage) => void;
+}
+
+const WSContext = createContext<WSContextValue | undefined>(undefined);
+
+export function WebSocketProvider({ children }: { children: ReactNode }) {
+  const ws = useWebSocket();
+  return <WSContext.Provider value={ws}>{children}</WSContext.Provider>;
+}
+
+export function useWS(): WSContextValue {
+  const ctx = useContext(WSContext);
+  if (!ctx) throw new Error('useWS must be used within WebSocketProvider');
+  return ctx;
+}

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Header from "@/components/layout/header";
 import Sidebar from "@/components/layout/sidebar";
 import MessagesSection from "@/pages/messages-section";
@@ -9,7 +9,10 @@ import ContactsSection from "@/pages/contacts-section";
 import SettingsSection from "@/pages/settings-section";
 import WikiSection from "@/pages/wiki-section";
 import CallModal from "@/components/call-modal";
-import { useWebSocket } from "@/hooks/useWebSocket";
+import { useWS } from "@/context/WebSocketContext";
+import { useAuth } from "@/hooks/use-auth";
+import { useToast } from "@/hooks/use-toast";
+import { useTranslation } from "react-i18next";
 import { SectionType } from "@/types/sections";
 import { useChat } from "@/context/ChatContext";
 import { useMessageSync } from "@/hooks/useMessageSync";
@@ -23,8 +26,11 @@ export default function HomePage() {
     id: number;
     name: string;
   } | null>(null);
-  const { connectionStatus } = useWebSocket();
-  const { setChatUser } = useChat();
+  const { connectionStatus, lastRawMessage } = useWS();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const { t } = useTranslation();
+  const { chatUser, setChatUser } = useChat();
   useMessageSync();
 
   const handleStartCall = (
@@ -50,6 +56,16 @@ export default function HomePage() {
   const toggleSidebar = () => {
     setIsSidebarOpen(!isSidebarOpen);
   };
+
+  useEffect(() => {
+    if (!lastRawMessage) return;
+    if (lastRawMessage.type !== 'chat') return;
+    const msg = lastRawMessage.payload as { senderId: number; content: string };
+    if (!user) return;
+    if (msg.senderId === user.id) return;
+    if (chatUser && msg.senderId === chatUser.id) return;
+    toast({ title: t('messages.newMessage'), description: msg.content });
+  }, [lastRawMessage, chatUser, user, toast, t]);
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useEffect, useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/use-auth';
 import { useChat } from '@/context/ChatContext';
-import { useWebSocket } from '@/hooks/useWebSocket';
+import { useWS } from '@/context/WebSocketContext';
 import { usePeerConnection } from '@/hooks/usePeerConnection';
 import { createApiClient } from '@/lib/api-client';
 import {
@@ -65,7 +65,7 @@ export default function MessagesSection({ onStartCall }: Props) {
   const { user } = useAuth();
   const apiClient = createApiClient();
   const { t } = useTranslation();
-  const { connectionStatus, lastRawMessage, sendRaw } = useWebSocket();
+  const { connectionStatus, lastRawMessage, sendRaw } = useWS();
 
   const { chatUser: selectedUser, setChatUser: setSelectedUser } = useChat();
   const [msgInput, setMsgInput] = useState('');


### PR DESCRIPTION
## Summary
- provide a WebSocket context to share one connection
- show toast notifications when receiving messages outside the active chat

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*