### PR TITLE
Fix call modal initials

### DIFF
--- a/client/src/components/call-modal.tsx
+++ b/client/src/components/call-modal.tsx
@@ -58,9 +58,11 @@ export default function CallModal({
   };
 
   // Get initials for avatar
-  const getInitials = (name: string) => {
+  const getInitials = (name?: string) => {
+    if (!name) return "?";
     return name
       .split(" ")
+      .filter(Boolean)
       .map((n) => n[0])
       .join("")
       .toUpperCase();


### PR DESCRIPTION
## Summary
- handle missing recipient name in call modal avatar initials

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*
- `pnpm install` *(fails: request to registry.npmjs.org failed EHOSTUNREACH)*