### PR TITLE
Add password change option

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -89,7 +89,9 @@
     "phone": "Phone",
     "location": "Location",
     "department": "Department",
-    "position": "Position"
+    "position": "Position",
+    "currentPassword": "Current Password",
+    "newPassword": "New Password"
   },
   "settings": {
     "title": "Settings",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -101,7 +101,9 @@
     "phone": "Телефон",
     "location": "Местоположение",
     "department": "Отдел",
-    "position": "Должность"
+    "position": "Должность",
+    "currentPassword": "Текущий пароль",
+    "newPassword": "Новый пароль"
   },
   "settings": {
     "title": "Настройки",

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -25,6 +25,12 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
 import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon, ArrowLeft } from 'lucide-react';
 import { useLocation } from 'wouter';
 
@@ -76,6 +82,102 @@ const SettingsPage: React.FC = () => {
       duration: 2000,
     });
   };
+
+  const changePasswordSchema = z
+    .object({
+      currentPassword: z.string().min(1, 'Current password is required'),
+      newPassword: z.string().min(6, 'Password too short'),
+      confirmPassword: z.string(),
+    })
+    .refine((data) => data.newPassword === data.confirmPassword, {
+      message: 'Passwords do not match',
+      path: ['confirmPassword'],
+    });
+
+  function ChangePasswordForm() {
+    const form = useForm<z.infer<typeof changePasswordSchema>>({
+      resolver: zodResolver(changePasswordSchema),
+    });
+
+    const mutation = useMutation({
+      mutationFn: async (data: z.infer<typeof changePasswordSchema>) => {
+        const { confirmPassword, ...payload } = data;
+        const res = await fetch('/api/change-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            currentPassword: payload.currentPassword,
+            newPassword: payload.newPassword,
+          }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || 'Failed to change password');
+        }
+      },
+      onSuccess: () => {
+        toast({ title: t('common.changesApplied') });
+        form.reset();
+      },
+      onError: (error: Error) => {
+        toast({ variant: 'destructive', title: error.message });
+      },
+    });
+
+    const onSubmit = (data: z.infer<typeof changePasswordSchema>) => {
+      mutation.mutate(data);
+    };
+
+    return (
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="currentPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.currentPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="newPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('profile.newPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('auth.confirmPassword')}</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" disabled={mutation.isPending}>
+            {t('profile.changePassword')}
+          </Button>
+        </form>
+      </Form>
+    );
+  }
 
   return (
     <div className="container mx-auto py-10">
@@ -187,7 +289,7 @@ const SettingsPage: React.FC = () => {
             </CardHeader>
             <CardContent className="space-y-4">
               <p>{t('settings.accountSettings')}</p>
-              {/* Account settings will be implemented here */}
+              <ChangePasswordForm />
             </CardContent>
           </Card>
         </TabsContent>

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -1,6 +1,7 @@
 /// <reference path="../types/express-session.d.ts" />
 import 'express-session';
 import { Router, Request, Response } from 'express';
+import bcrypt from 'bcrypt';
 import { login, register } from '../lib/api/auth';
 import { db } from '../db'; // Уже есть
 import { logger } from '../util/logger'; // Уже есть
@@ -99,6 +100,53 @@ router.get('/user', isAuthenticated, async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Server error' });
   }
 });
+
+/**
+ * POST /api/change-password
+ * Смена пароля текущего пользователя.
+ * Тело: { currentPassword: string; newPassword: string }
+ */
+router.post(
+  '/change-password',
+  isAuthenticated,
+  async (req: Request, res: Response) => {
+    try {
+      const { currentPassword, newPassword } = req.body as {
+        currentPassword: string;
+        newPassword: string;
+      };
+      const userId = req.session.userId as number;
+
+      if (!currentPassword || !newPassword) {
+        return res.status(400).json({ error: 'Missing fields' });
+      }
+
+      const result = await db!.query<{ password: string }>(
+        'SELECT password FROM users WHERE id = $1',
+        [userId]
+      );
+      const user = result.rows[0];
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      const valid = await bcrypt.compare(currentPassword, user.password);
+      if (!valid) {
+        return res.status(400).json({ error: 'Incorrect current password' });
+      }
+
+      const salt = await bcrypt.genSalt(10);
+      const hashed = await bcrypt.hash(newPassword, salt);
+
+      await db!.query('UPDATE users SET password = $1 WHERE id = $2', [hashed, userId]);
+
+      res.json({ success: true });
+    } catch (err) {
+      logger.error('Change password error:', err);
+      res.status(500).json({ error: 'Server error' });
+    }
+  }
+);
 
 /**
  * PATCH /api/users/status


### PR DESCRIPTION
## Summary
- allow changing password via /api/change-password
- add password change form under account settings
- extend translations

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*