### PR TITLE
Fix online status display and use heartbeat

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,10 +11,12 @@ import { ChatProvider } from "./context/ChatContext";
 import { WindowFrameHeader } from "./components/ui/window-frame";
 import { useElectron } from "./hooks/use-electron";
 import { useEffect, useState } from "react";
+import { useUserStatusHeartbeat } from "./hooks/useUserStatus";
 
 function AppContent() {
   const { user, isLoading } = useAuth();
   const { isElectron } = useElectron();
+  useUserStatusHeartbeat();
 
   useEffect(() => {
     if (isElectron) {

--- a/client/src/hooks/useUserStatus.ts
+++ b/client/src/hooks/useUserStatus.ts
@@ -2,33 +2,52 @@
 import { useEffect } from 'react';
 import { useAuth } from './use-auth';
 import { apiClient } from '@/lib/api-client';
+import { useQueryClient } from '@tanstack/react-query';
 
 export function useUserStatusHeartbeat() {
   const { user } = useAuth();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!user) return;
     // сразу помечаем online
-    apiClient.request('/users/status', {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ isonline: 1 }),
-    }).catch(console.error);
-
-    const interval = setInterval(() => {
-      apiClient.request('/users/status', {
+    apiClient
+      .request('/users/status', {
         method: 'PATCH',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isonline: 1 }),
-      }).catch(console.error);
+      })
+      .then(() => {
+        queryClient.setQueryData(['/api/user'], (prev: any) =>
+          prev ? { ...prev, isOnline: 1 } : prev
+        );
+      })
+      .catch(console.error);
+
+    const interval = setInterval(() => {
+      apiClient
+        .request('/users/status', {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ isonline: 1 }),
+        })
+        .then(() => {
+          queryClient.setQueryData(['/api/user'], (prev: any) =>
+            prev ? { ...prev, isOnline: 1 } : prev
+          );
+        })
+        .catch(console.error);
     }, 10_000);
 
     const setOffline = () => {
       navigator.sendBeacon(
         `${import.meta.env.VITE_API_URL}/api/users/status`,
         JSON.stringify({ isonline: 0 })
+      );
+      queryClient.setQueryData(['/api/user'], (prev: any) =>
+        prev ? { ...prev, isOnline: 0 } : prev
       );
     };
     window.addEventListener('beforeunload', setOffline);
@@ -38,5 +57,5 @@ export function useUserStatusHeartbeat() {
       setOffline();
       window.removeEventListener('beforeunload', setOffline);
     };
-  }, [user]);
+  }, [user, queryClient]);
 }


### PR DESCRIPTION
## Summary
- keep user status up to date by patching cached `/api/user`
- run heartbeat hook from main app

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*