### PR TITLE
Fix message sync and peer connection

### DIFF
--- a/client/src/hooks/usePeerConnection.ts
+++ b/client/src/hooks/usePeerConnection.ts
@@ -37,10 +37,6 @@ export function usePeerConnection(
       onSignalRef.current(sig);
     });
 
-    if (incomingSignal) {
-      console.debug('P2P received signal', incomingSignal);
-      peer.signal(incomingSignal);
-    }
 
     peer.on('connect', () => {
       console.info('P2P connection open');
@@ -70,7 +66,18 @@ export function usePeerConnection(
     return () => {
       peer.destroy();
     };
-  }, [enabled, initiator, incomingSignal]);
+  }, [enabled, initiator]);
+
+  useEffect(() => {
+    if (incomingSignal && peerRef.current) {
+      console.debug('P2P received signal', incomingSignal);
+      try {
+        peerRef.current.signal(incomingSignal);
+      } catch (err) {
+        console.error('P2P signal error', err);
+      }
+    }
+  }, [incomingSignal]);
 
   const send = (msg: PeerMessage) => {
     if (enabled && peerRef.current?.connected) {

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -130,7 +130,15 @@ export default function MessagesSection({ onStartCall }: Props) {
 
   useEffect(() => {
     if (user && selectedUser && messages.length > 0) {
-      saveMessages(user.id, selectedUser.id, messages);
+      setLocalMessages((prev) => {
+        const merged = Array.from(
+          new Map(
+            [...prev, ...messages].map((m) => [m.id, m])
+          ).values()
+        );
+        saveMessages(user.id, selectedUser.id, merged);
+        return merged;
+      });
     }
   }, [messages, user, selectedUser]);
 


### PR DESCRIPTION
## Summary
- keep old messages in localStorage when new messages are fetched
- avoid resetting the peer connection whenever a signal arrives

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to compile due to missing modules)*