### PR TITLE
Add audio device settings and basic call feature

### DIFF
--- a/client/src/components/call-modal.tsx
+++ b/client/src/components/call-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -11,6 +11,10 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { MicOffIcon, VideoOffIcon, PhoneOffIcon, UserIcon } from "lucide-react";
 import { useTranslations } from "@/hooks/use-translations";
+import { useAuth } from "@/hooks/use-auth";
+import { useWebSocket } from "@/hooks/useWebSocket";
+import { useSettings } from "@/context/SettingsContext";
+import { useCallConnection } from "@/hooks/useCallConnection";
 
 export type TranslationKey =  "call.video" | "call.audio" | "call.in_progress" | "common.cancel";
 
@@ -35,6 +39,42 @@ export default function CallModal({
   const [isMuted, setIsMuted] = useState(false);
   const [isVideoOff, setIsVideoOff] = useState(false);
   const { t } = useTranslations();
+  const { user } = useAuth();
+  const { sendRaw, lastRawMessage } = useWebSocket();
+  const { audioInputId } = useSettings();
+  const [incomingSignal, setIncomingSignal] = useState<any>();
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const isInitiator = user && recipient ? user.id < recipient.id : false;
+  const { localStream, remoteStream } = useCallConnection(
+    isInitiator,
+    (signal) =>
+      sendRaw({ type: "p2p-signal", payload: { to: recipient.id, signal } }),
+    incomingSignal,
+    audioInputId
+  );
+
+  useEffect(() => {
+    if (
+      lastRawMessage?.type === "p2p-signal" &&
+      (lastRawMessage as any).payload.from === recipient.id
+    ) {
+      setIncomingSignal((lastRawMessage as any).payload.signal);
+    }
+  }, [lastRawMessage, recipient]);
+
+  useEffect(() => {
+    if (audioRef.current && remoteStream) {
+      audioRef.current.srcObject = remoteStream;
+      audioRef.current.play().catch(() => {});
+    }
+  }, [remoteStream]);
+
+  useEffect(() => {
+    if (localStream) {
+      localStream.getAudioTracks().forEach((t) => (t.enabled = !isMuted));
+    }
+  }, [isMuted, localStream]);
 
   // Start call timer when modal opens
   useEffect(() => {
@@ -134,6 +174,7 @@ export default function CallModal({
           <p className="text-primary-300 mt-6">
             {formatDuration(callDuration)}
           </p>
+          <audio ref={audioRef} className="hidden" />
         </div>
 
         {/* Video placeholder - in a real app this would connect to WebRTC */}

--- a/client/src/context/SettingsContext.tsx
+++ b/client/src/context/SettingsContext.tsx
@@ -6,8 +6,10 @@ export type Theme = 'light' | 'dark' | 'system';
 interface SettingsContextType {
   theme: Theme;
   language: string;
+  audioInputId: string | null;
   setTheme: (theme: Theme) => void;
   setLanguage: (lang: string) => Promise<void>;
+  setAudioInputId: (id: string | null) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -25,10 +27,12 @@ function applyTheme(theme: Theme) {
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('system');
   const [language, setLanguageState] = useState<string>(i18n.language || 'en');
+  const [audioInputId, setAudioInputIdState] = useState<string | null>(null);
 
   useEffect(() => {
     const storedTheme = localStorage.getItem('theme') as Theme | null;
     const storedLang = localStorage.getItem('language');
+    const storedAudio = localStorage.getItem('audioInputId');
     if (storedTheme) {
       setThemeState(storedTheme);
       applyTheme(storedTheme);
@@ -36,6 +40,9 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     if (storedLang) {
       setLanguageState(storedLang);
       i18n.changeLanguage(storedLang).catch(console.error);
+    }
+    if (storedAudio) {
+      setAudioInputIdState(storedAudio);
     }
   }, []);
 
@@ -51,8 +58,23 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     await i18n.changeLanguage(lang);
   };
 
+  const setAudioInputId = (id: string | null) => {
+    setAudioInputIdState(id);
+    if (id) localStorage.setItem('audioInputId', id);
+    else localStorage.removeItem('audioInputId');
+  };
+
   return (
-    <SettingsContext.Provider value={{ theme, language, setTheme, setLanguage }}>
+    <SettingsContext.Provider
+      value={{
+        theme,
+        language,
+        audioInputId,
+        setTheme,
+        setLanguage,
+        setAudioInputId,
+      }}
+    >
       {children}
     </SettingsContext.Provider>
   );

--- a/client/src/hooks/useAudioDevices.ts
+++ b/client/src/hooks/useAudioDevices.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export interface AudioDevice {
+  deviceId: string;
+  label: string;
+}
+
+export function useAudioDevices() {
+  const [devices, setDevices] = useState<AudioDevice[]>([]);
+
+  const updateDevices = async () => {
+    try {
+      const list = await navigator.mediaDevices.enumerateDevices();
+      setDevices(
+        list
+          .filter((d) => d.kind === 'audioinput')
+          .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId}` }))
+      );
+    } catch (err) {
+      console.warn('Failed to enumerate audio devices', err);
+      setDevices([]);
+    }
+  };
+
+  useEffect(() => {
+    updateDevices();
+  }, []);
+
+  return { devices, refresh: updateDevices };
+}

--- a/client/src/hooks/useCallConnection.ts
+++ b/client/src/hooks/useCallConnection.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+import SimplePeer, { Instance as Peer, SignalData } from 'simple-peer';
+
+export type CallStatus = 'init' | 'connecting' | 'open' | 'closed' | 'error';
+
+export function useCallConnection(
+  initiator: boolean,
+  onSignal: (signal: SignalData) => void,
+  incomingSignal?: SignalData,
+  audioDeviceId?: string | null
+) {
+  const [status, setStatus] = useState<CallStatus>('init');
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+  const [localStream, setLocalStream] = useState<MediaStream | null>(null);
+  const peerRef = useRef<Peer>();
+  const onSignalRef = useRef(onSignal);
+  onSignalRef.current = onSignal;
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let peer: Peer | undefined;
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: audioDeviceId ? { deviceId: { exact: audioDeviceId } } : true,
+        });
+        setLocalStream(stream);
+        peer = new SimplePeer({
+          initiator,
+          trickle: true,
+          stream,
+          config: { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] },
+        });
+        peer.on('signal', (sig) => onSignalRef.current(sig));
+        if (incomingSignal) peer.signal(incomingSignal);
+        peer.on('connect', () => setStatus('open'));
+        peer.on('stream', (s) => setRemoteStream(s));
+        peer.on('close', () => setStatus('closed'));
+        peer.on('error', () => setStatus('error'));
+        peerRef.current = peer;
+        setStatus('connecting');
+      } catch (err) {
+        console.error('getUserMedia failed', err);
+        setStatus('error');
+      }
+    };
+    start();
+    return () => {
+      if (peer) peer.destroy();
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, [initiator, incomingSignal, audioDeviceId]);
+
+  return { status, remoteStream, localStream };
+}

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -101,6 +101,8 @@
     "notifications": "Notifications",
     "appearance": "Appearance",
     "language": "Language",
+    "audioInput": "Microphone",
+    "noAudioDevices": "No devices found",
     "darkMode": "Dark Mode",
     "lightMode": "Light Mode",
     "theme": "Theme",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -113,6 +113,8 @@
     "notifications": "Уведомления",
     "appearance": "Внешний вид",
     "language": "Язык",
+    "audioInput": "Микрофон",
+    "noAudioDevices": "Устройства не найдены",
     "darkMode": "Темный режим",
     "lightMode": "Светлый режим",
     "theme": "Тема",

--- a/client/src/pages/settings-section.tsx
+++ b/client/src/pages/settings-section.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "../hooks/use-auth";
 import { useTranslations } from "@/hooks/use-translations";
 import { useSettings } from "@/context/SettingsContext";
+import { useAudioDevices } from "@/hooks/useAudioDevices";
 import {
   Select,
   SelectTrigger,
@@ -13,7 +14,8 @@ import { Label } from "@/components/ui/label";
 export default function SettingsSection() {
   const { user } = useAuth();
   const { t } = useTranslations();
-  const { language, setLanguage } = useSettings();
+  const { language, setLanguage, audioInputId, setAudioInputId } = useSettings();
+  const { devices } = useAudioDevices();
 
   if (!user) return null;
 
@@ -29,6 +31,26 @@ export default function SettingsSection() {
           <SelectContent>
             <SelectItem value="ru">Русский</SelectItem>
             <SelectItem value="en">English</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2 max-w-xs mt-4">
+        <Label htmlFor="audioInput">{t('settings.audioInput')}</Label>
+        <Select value={audioInputId ?? ''} onValueChange={setAudioInputId}>
+          <SelectTrigger id="audioInput">
+            <SelectValue placeholder={t('settings.audioInput')} />
+          </SelectTrigger>
+          <SelectContent>
+            {devices.length === 0 ? (
+              <SelectItem value="">{t('settings.noAudioDevices')}</SelectItem>
+            ) : (
+              devices.map((d) => (
+                <SelectItem key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </SelectItem>
+              ))
+            )}
           </SelectContent>
         </Select>
       </div>


### PR DESCRIPTION
## Summary
- enumerate audio devices with `useAudioDevices`
- store selected microphone in `SettingsContext`
- allow choosing microphone in Settings page
- implement `useCallConnection` to request microphone access and exchange WebRTC signals
- use new hook in `CallModal` so calls use actual audio
- add translation keys for new settings

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' etc.)*
