### PR TITLE
Fix duplicate messages after sending

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -265,6 +265,7 @@ export default function MessagesSection({ onStartCall }: Props) {
 
     console.log('Sending message', msgInput);
 
+    const tempId = Date.now();
     if (p2pStatus === 'open') {
       sendP2P({
         senderId: user!.id,
@@ -272,23 +273,10 @@ export default function MessagesSection({ onStartCall }: Props) {
         content: msgInput,
         file: fileData || undefined,
       });
-    } else {
-      await apiClient.request<Message>('/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          receiverId: selectedUser.id,
-          content: msgInput,
-        }),
-      });
-      console.info('Message sent to server', {
-        from: user!.id,
-        to: selectedUser.id,
-      });
     }
 
-    const msg: StoredMessage = {
-      id: Date.now(),
+    const tempMsg: StoredMessage = {
+      id: tempId,
       senderId: user!.id,
       receiverId: selectedUser.id,
       content: msgInput,
@@ -296,8 +284,43 @@ export default function MessagesSection({ onStartCall }: Props) {
       synced: false,
       file: fileData || undefined,
     };
-    appendMessage(user!.id, selectedUser.id, msg);
-    setLocalMessages((prev) => [...prev, msg]);
+
+    appendMessage(user!.id, selectedUser.id, tempMsg);
+    setLocalMessages((prev) => [...prev, tempMsg]);
+
+    if (p2pStatus !== 'open') {
+      try {
+        const saved = await apiClient.request<Message>('/messages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            receiverId: selectedUser.id,
+            content: msgInput,
+          }),
+        });
+
+        console.info('Message sent to server', {
+          from: user!.id,
+          to: selectedUser.id,
+        });
+
+        // replace temporary message with saved one
+        const updated: StoredMessage = {
+          ...saved,
+          file: fileData || undefined,
+          synced: true,
+        };
+        setLocalMessages((prev) =>
+          prev.map((m) => (m.id === tempId ? updated : m))
+        );
+        const stored = loadMessages(user!.id, selectedUser.id).map((m) =>
+          m.id === tempId ? updated : m
+        );
+        saveMessages(user!.id, selectedUser.id, stored);
+      } catch (err) {
+        console.error('Failed to send message', err);
+      }
+    }
 
     setMsgInput('');
     setFileData(null);

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -286,10 +286,11 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
     // пытаемся отправить сразу через WS
     const delivered = sendChatMessage(receiverId, { senderId, receiverId, content });
 
-    // сохраняем в БД с пометкой статуса
-    await db!.query(
+    // сохраняем в БД с пометкой статуса и возвращаем созданную запись
+    const result = await db!.query(
       `INSERT INTO messages (sender_id, receiver_id, content, timestamp, status)
-       VALUES ($1, $2, $3, NOW(), $4)`,
+       VALUES ($1, $2, $3, NOW(), $4)
+       RETURNING id, sender_id AS "senderId", receiver_id AS "receiverId", content, timestamp, status`,
       [senderId, receiverId, content, delivered ? 'delivered' : 'pending']
     );
 
@@ -298,7 +299,7 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
       'Message stored on server'
     );
 
-    res.json({ success: true });
+    res.json(result.rows[0]);
   } catch (error) {
     logger.error({ err: error }, 'Error sending message');
     const detail = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- return saved message from `/api/messages`
- handle returned message on the client and replace temp message

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog', etc.)*