### PR TITLE
Align chat messages to bottom

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -34,7 +34,7 @@ export function MessageList({ messages, myId }: MessageListProps) {
   }
 
   return (
-    <div className="space-y-3">
+    <div className="min-h-full flex flex-col justify-end space-y-3">
       {messages.map((m) => (
         <div
           key={m.id}


### PR DESCRIPTION
## Summary
- show message bubbles at the bottom of the chat window when the list is short

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*