### PR TITLE
Reduce debug noise during calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ pnpm exec jest
 
 Copy `.env.example` to `.env` and fill in the required values before running the application.
 
+The `LOG_LEVEL` environment variable controls server log verbosity. Leaving it
+unset uses `info` level logging. Set `LOG_LEVEL=debug` for detailed WebSocket
+traces when troubleshooting connection issues.
+

--- a/server/src/util/logger.ts
+++ b/server/src/util/logger.ts
@@ -1,7 +1,8 @@
 import pino, { Logger } from 'pino';
 
 export const logger: Logger = pino({
-  level: process.env.LOG_LEVEL ?? 'debug',
+  // Default to info to avoid overwhelming logs unless LOG_LEVEL=debug is set
+  level: process.env.LOG_LEVEL ?? 'info',
   transport:
     process.env.NODE_ENV === 'production'
       ? undefined

--- a/server/src/ws.ts
+++ b/server/src/ws.ts
@@ -55,11 +55,18 @@ export function initWebSocket(
         .catch((e) => logger.error('Set online failed:', e));
     }
 
-    // Обработка входящих P2P-сигналов
+    // Обработка входящих сообщений
     ws.on('message', (data) => {
-      logger.debug(`WS message from ${userId}: ${data}`);
+      let msg: any;
       try {
-        const msg = JSON.parse(data.toString());
+        msg = JSON.parse(data.toString());
+        if (msg.type === 'p2p-signal') {
+          logger.debug(
+            `WS p2p-signal from ${userId} to ${(msg.payload as any).to}`
+          );
+        } else {
+          logger.debug(`WS message from ${userId}: ${data}`);
+        }
         if (msg.type === 'p2p-signal') {
           const { to, signal } = msg.payload as { to: number; signal: any };
           const targets = connections.get(to);

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,7 +1,8 @@
 import pino from 'pino';
 
 export const logger = pino({
-  level: process.env.LOG_LEVEL ?? 'debug',
+  // Log info by default; set LOG_LEVEL=debug for verbose output
+  level: process.env.LOG_LEVEL ?? 'info',
   transport: process.env.NODE_ENV === 'development'
     ? { target: 'pino-pretty', options: { singleLine: true } }
     : undefined,
@@ -10,3 +11,4 @@ export const logger = pino({
 export const preview = (v: unknown) =>
   typeof v === 'string' ? v.slice(0, 120) :
   typeof v === 'object' ? JSON.stringify(v).slice(0,120) : v;
+


### PR DESCRIPTION
## Summary
- default logger level to `info`
- trim WebSocket logs for p2p signals
- mention `LOG_LEVEL` in README

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog', etc.)*