### PR TITLE
Fix nullish coalesce syntax

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -308,7 +308,7 @@ export default function MessagesSection({ onStartCall }: Props) {
         // replace temporary message with saved one
         const updated: StoredMessage = {
           ...saved,
-          file: saved.file ?? fileData || undefined,
+          file: (saved.file ?? fileData) || undefined,
           synced: true,
         };
         setLocalMessages((prev) =>


### PR DESCRIPTION
## Summary
- fix usage of nullish coalescing mixed with logical OR in `messages-section`

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to resolve modules)*
