### PR TITLE
Fix timestamps for messages

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -305,19 +305,21 @@ export default function MessagesSection({ onStartCall }: Props) {
           to: selectedUser.id,
         });
 
-        // replace temporary message with saved one
-        const updated: StoredMessage = {
-          ...saved,
-          file: (saved.file ?? fileData) || undefined,
-          synced: true,
-        };
-        setLocalMessages((prev) =>
-          prev.map((m) => (m.id === tempId ? updated : m))
-        );
-        const stored = loadMessages(user!.id, selectedUser.id).map((m) =>
-          m.id === tempId ? updated : m
-        );
-        saveMessages(user!.id, selectedUser.id, stored);
+        if (saved) {
+          // replace temporary message with saved one
+          const updated: StoredMessage = {
+            ...saved,
+            file: (saved.file ?? fileData) || undefined,
+            synced: true,
+          };
+          setLocalMessages((prev) =>
+            prev.map((m) => (m.id === tempId ? updated : m))
+          );
+          const stored = loadMessages(user!.id, selectedUser.id).map((m) =>
+            m.id === tempId ? updated : m
+          );
+          saveMessages(user!.id, selectedUser.id, stored);
+        }
       } catch (err) {
         console.error('Failed to send message', err);
       }

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -295,8 +295,8 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
     const senderId = req.session.userId as number;
 
     const insert = await db!.query(
-      `INSERT INTO messages (sender_id, receiver_id, content, timestamp, status)
-       VALUES ($1, $2, $3, NOW(), 'pending')
+      `INSERT INTO messages (sender_id, receiver_id, content, status)
+       VALUES ($1, $2, $3, 'pending')
        RETURNING id, sender_id AS "senderId", receiver_id AS "receiverId", content, timestamp, status`,
       [senderId, receiverId, content]
     );

--- a/shared/electron-shared/schema/messages.ts
+++ b/shared/electron-shared/schema/messages.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, date } from "drizzle-orm/pg-core";
+import { pgTable, serial, integer, text, timestamp } from "drizzle-orm/pg-core";
 import { users } from "./users";
 
 /** chat / DM messages */
@@ -8,7 +8,7 @@ export const messages = pgTable("messages", {
   receiverId: integer("receiver_id"),
   groupId: integer("group_id"),
   content: text("content").notNull(),
-  timestamp: date("timestamp").notNull(),
+  timestamp: timestamp("timestamp").defaultNow().notNull(),
   isRead: integer("is_read").default(0),
   status: text("status").default("pending").notNull()
 });


### PR DESCRIPTION
## Summary
- use database default timestamp when creating messages
- update electron schema to default timestamp
- guard against undefined API response in messages page

## Testing
- `pnpm run type-check`
