### PR TITLE
Fix message storage update when API returns nothing

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -305,19 +305,21 @@ export default function MessagesSection({ onStartCall }: Props) {
           to: selectedUser.id,
         });
 
-        // replace temporary message with saved one
-        const updated: StoredMessage = {
-          ...saved,
-          file: (saved.file ?? fileData) || undefined,
-          synced: true,
-        };
-        setLocalMessages((prev) =>
-          prev.map((m) => (m.id === tempId ? updated : m))
-        );
-        const stored = loadMessages(user!.id, selectedUser.id).map((m) =>
-          m.id === tempId ? updated : m
-        );
-        saveMessages(user!.id, selectedUser.id, stored);
+        if (saved) {
+          // replace temporary message with saved one
+          const updated: StoredMessage = {
+            ...saved,
+            file: (saved.file ?? fileData) || undefined,
+            synced: true,
+          };
+          setLocalMessages((prev) =>
+            prev.map((m) => (m.id === tempId ? updated : m))
+          );
+          const stored = loadMessages(user!.id, selectedUser.id).map((m) =>
+            m.id === tempId ? updated : m
+          );
+          saveMessages(user!.id, selectedUser.id, stored);
+        }
       } catch (err) {
         console.error('Failed to send message', err);
       }


### PR DESCRIPTION
## Summary
- check for `saved` being undefined before updating stored messages

## Testing
- `pnpm run type-check`