### PR TITLE
Increase JSON body size limit

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -13,7 +13,8 @@ export async function createApp() {
   // core middleware
   app.use(morgan('dev'));
   app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
-  app.use(express.json());
+  // Allow larger batched requests
+  app.use(express.json({ limit: '5mb' }));
 
   // HTTP logging middleware
   app.use(pinoHttp({ logger, autoLogging: false }));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -34,7 +34,8 @@ export function createApp(): Express {
   /* ───────── COMMON MIDDLEWARE ───────── */
   app.use(pinoHttp({ logger: logger as any, autoLogging: false }));
   app.use(morgan('dev'));
-  app.use(express.json());
+  // Increase JSON body size limit to handle batched messages
+  app.use(express.json({ limit: '5mb' }));
   app.use(
     cors({
       origin: ['http://localhost:5173', 'app://.*'],


### PR DESCRIPTION
## Summary
- allow larger POST payloads by bumping the JSON body size limit in Express

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
