### PR TITLE
Fix message status update

### DIFF
--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -318,7 +318,9 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
     const delivered = sendChatMessage(receiverId, { ...message, file: filePath });
 
     if (delivered) {
-      await db!.query('UPDATE messages SET status = \"delivered\" WHERE id = $1', [message.id]);
+      await db!.query("UPDATE messages SET status = 'delivered' WHERE id = $1", [
+        message.id,
+      ]);
       message.status = 'delivered';
     }
 


### PR DESCRIPTION
## Summary
- ensure SQL uses single quotes when updating message status

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`