### PR TITLE
Add admin panel placeholder

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from 'react-hot-toast';
 import AuthPage from './pages/auth-page';
 import HomePage from "./pages/home-page";
 import SettingsPage from './pages/settings-page';
+import AdminPage from './pages/admin-page';
 import WikiArticlePage from './pages/wiki-article-page';
 import { Route, Switch, Redirect } from 'wouter';
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -38,6 +39,9 @@ function AppContent() {
           </Route>
           <Route path="/settings">
             {user ? <SettingsPage /> : <Redirect to="/auth" />}
+          </Route>
+          <Route path="/admin">
+            {user && user.isAdmin ? <AdminPage /> : <Redirect to="/" />}
           </Route>
           <Route path="/wiki/:id">
             {user ? <WikiArticlePage /> : <Redirect to="/auth" />}

--- a/client/src/pages/admin-page.tsx
+++ b/client/src/pages/admin-page.tsx
@@ -1,0 +1,21 @@
+import { useAuth } from '@/hooks/use-auth';
+import { Redirect, useLocation } from 'wouter';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
+
+export default function AdminPage() {
+  const { user } = useAuth();
+  const [, setLocation] = useLocation();
+  const { t } = useTranslation();
+
+  if (!user) return <Redirect to="/auth" />;
+  if (!user.isAdmin) return <Redirect to="/" />;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold mb-4">{t('nav.admin')} Panel</h1>
+      <p className="text-gray-600 mb-6">This area is under construction.</p>
+      <Button onClick={() => setLocation('/')}>{t('common.back')}</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add AdminPage placeholder for admins only
- route `/admin` to AdminPage

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
