### PR TITLE
Fix p2p status colour and show tooltip legend

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import MessageStatusDot from './message-status-dot';
 
 export interface MessageItem {
   id: number;
@@ -39,43 +40,35 @@ export function MessageList({ messages, myId }: MessageListProps) {
 
   return (
     <div className="min-h-full flex flex-col space-y-3">
-      {messages.map((m) => {
-        let statusColor = 'bg-gray-400';
-        if (m.error) {
-          statusColor = 'bg-red-500';
-        } else if (!m.synced || m.status === 'pending') {
-          statusColor = 'bg-yellow-500';
-        } else if (m.transport === 'p2p') {
-          statusColor = 'bg-blue-500';
-        } else if (m.status === 'read') {
-          statusColor = 'bg-green-500';
-        }
-
-        return (
-          <div
-            key={m.id}
-            className={`max-w-[80%] rounded-xl px-4 py-2 text-sm break-words space-y-2 ${
-              m.senderId === myId
-                ? 'ml-auto bg-primary-100 text-primary-900 dark:bg-primary-700 dark:text-white'
-                : 'mr-auto bg-gray-200 text-black dark:bg-gray-700 dark:text-white'
-            }`}
-          >
-            <div>{m.content}</div>
-            {m.file && (
-              m.file.startsWith('data:image') ? (
-                <img src={m.file} alt="attachment" className="max-w-xs rounded-md" />
-              ) : (
-                <a href={m.file} download className="underline text-blue-600 dark:text-blue-400">
-                  Download file
-                </a>
-              )
-            )}
-            <div className="flex justify-end">
-              <span className={`inline-block w-2 h-2 rounded-full ${statusColor}`} />
-            </div>
+      {messages.map((m) => (
+        <div
+          key={m.id}
+          className={`max-w-[80%] rounded-xl px-4 py-2 text-sm break-words space-y-2 ${
+            m.senderId === myId
+              ? 'ml-auto bg-primary-100 text-primary-900 dark:bg-primary-700 dark:text-white'
+              : 'mr-auto bg-gray-200 text-black dark:bg-gray-700 dark:text-white'
+          }`}
+        >
+          <div>{m.content}</div>
+          {m.file && (
+            m.file.startsWith('data:image') ? (
+              <img src={m.file} alt="attachment" className="max-w-xs rounded-md" />
+            ) : (
+              <a href={m.file} download className="underline text-blue-600 dark:text-blue-400">
+                Download file
+              </a>
+            )
+          )}
+          <div className="flex justify-end">
+            <MessageStatusDot
+              status={m.status}
+              transport={m.transport}
+              synced={m.synced}
+              error={m.error}
+            />
           </div>
-        );
-      })}
+        </div>
+      ))}
       <div ref={endRef} />
     </div>
   );

--- a/client/src/components/message-status-dot.tsx
+++ b/client/src/components/message-status-dot.tsx
@@ -1,0 +1,61 @@
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { useTranslation } from 'react-i18next';
+
+export interface MessageStatusProps {
+  status?: 'pending' | 'delivered' | 'read';
+  transport?: 'server' | 'p2p';
+  synced?: boolean;
+  error?: boolean;
+}
+
+export function MessageStatusDot({ status, transport, synced, error }: MessageStatusProps) {
+  const { t } = useTranslation();
+
+  let color = 'bg-gray-400';
+  let key: 'pending' | 'p2p' | 'delivered' | 'read' | 'error' = 'delivered';
+
+  if (error) {
+    color = 'bg-red-500';
+    key = 'error';
+  } else if (!synced || status === 'pending') {
+    color = 'bg-yellow-500';
+    key = 'pending';
+  } else if (transport === 'p2p') {
+    color = 'bg-blue-500';
+    key = 'p2p';
+  } else if (status === 'read') {
+    color = 'bg-green-500';
+    key = 'read';
+  }
+
+  const legend = [
+    { color: 'bg-yellow-500', key: 'pending' },
+    { color: 'bg-blue-500', key: 'p2p' },
+    { color: 'bg-gray-400', key: 'delivered' },
+    { color: 'bg-green-500', key: 'read' },
+    { color: 'bg-red-500', key: 'error' },
+  ] as const;
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={`inline-block w-2 h-2 rounded-full ${color}`} />
+        </TooltipTrigger>
+        <TooltipContent className="space-y-1">
+          <div>{t(`messages.status.${key}`)}</div>
+          <div className="flex flex-col space-y-1 mt-1">
+            {legend.map(({ color, key }) => (
+              <div key={key} className="flex items-center gap-1">
+                <span className={`inline-block w-2 h-2 rounded-full ${color}`} />
+                <span className="text-xs">{t(`messages.status.${key}`)}</span>
+              </div>
+            ))}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default MessageStatusDot;

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -135,18 +135,17 @@ export default function MessagesSection({ onStartCall }: Props) {
   useEffect(() => {
     if (user && selectedUser && messages.length > 0) {
       setLocalMessages((prev) => {
-        const merged = Array.from(
-          new Map(
-            [
-              ...prev,
-              ...messages.map((m) => ({
-                ...m,
-                synced: true,
-                transport: 'server' as const,
-              })),
-            ].map((m) => [m.id, m])
-          ).values()
-        );
+        const map = new Map(prev.map((m) => [m.id, m]));
+        for (const srv of messages) {
+          const existing = map.get(srv.id);
+          map.set(srv.id, {
+            ...existing,
+            ...srv,
+            synced: true,
+            transport: existing?.transport ?? 'server',
+          });
+        }
+        const merged = Array.from(map.values());
         saveMessages(user.id, selectedUser.id, merged);
         return merged;
       });


### PR DESCRIPTION
## Summary
- keep p2p transport flag when merging server history
- add `MessageStatusDot` component with tooltip legend
- use new status dot in message list

## Testing
- `pnpm run type-check`