### PR TITLE
Fix message ordering and read status

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -9,7 +9,7 @@ export interface MessageItem {
   file?: string;
   synced?: boolean;
   transport?: 'server' | 'p2p';
-  status?: 'pending' | 'delivered' | 'read';
+  status?: 'pending' | 'delivered' | 'read' | 'p2p';
   error?: boolean;
 }
 

--- a/client/src/components/message-status-dot.tsx
+++ b/client/src/components/message-status-dot.tsx
@@ -2,7 +2,7 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/comp
 import { useTranslation } from 'react-i18next';
 
 export interface MessageStatusProps {
-  status?: 'pending' | 'delivered' | 'read';
+  status?: 'pending' | 'delivered' | 'read' | 'p2p';
   transport?: 'server' | 'p2p';
   synced?: boolean;
   error?: boolean;

--- a/client/src/lib/message-storage.ts
+++ b/client/src/lib/message-storage.ts
@@ -9,7 +9,7 @@ export interface StoredMessage {
   /** transport used to send the message */
   transport?: 'server' | 'p2p';
   /** delivery status from server */
-  status?: 'pending' | 'delivered' | 'read';
+  status?: 'pending' | 'delivered' | 'read' | 'p2p';
   /** set when sending to server failed */
   error?: boolean;
 }

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -38,7 +38,7 @@ export interface Message {
   receiverId: number;
   content: string;
   timestamp: string;
-  status?: 'pending' | 'delivered' | 'read';
+  status?: 'pending' | 'delivered' | 'read' | 'p2p';
   transport?: 'server' | 'p2p';
   synced?: boolean;
   error?: boolean;
@@ -225,7 +225,7 @@ export default function MessagesSection({ onStartCall }: Props) {
         timestamp: new Date().toISOString(),
         file: p2pMsg.file,
         transport: 'p2p',
-        status: 'delivered',
+        status: 'p2p',
         synced: true,
       };
       appendMessage(user!.id, selectedUser!.id, stored);
@@ -243,12 +243,10 @@ export default function MessagesSection({ onStartCall }: Props) {
     new Map(
       [...messages, ...localMessages].map((m) => [m.id, m]),
     ).values(),
-  ).sort(
-    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-  );
+  ).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
-  const trimmedMessages = combinedMessages.slice(-maxDisplay);
-  const visibleMessages = trimmedMessages.slice(-visibleCount);
+  const trimmedMessages = combinedMessages.slice(0, maxDisplay);
+  const visibleMessages = trimmedMessages.slice(0, visibleCount);
 
   useEffect(() => {
     setVisibleCount((c) => {
@@ -259,7 +257,11 @@ export default function MessagesSection({ onStartCall }: Props) {
   }, [trimmedMessages.length]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    if (e.currentTarget.scrollTop < 50) {
+    if (
+      e.currentTarget.scrollHeight - e.currentTarget.scrollTop -
+        e.currentTarget.clientHeight <
+      50
+    ) {
       setVisibleCount((c) =>
         Math.min(c + pageSize, Math.min(trimmedMessages.length, maxDisplay)),
       );
@@ -297,7 +299,7 @@ export default function MessagesSection({ onStartCall }: Props) {
       timestamp: new Date().toISOString(),
       synced: viaP2P ? true : false,
       transport: viaP2P ? 'p2p' : 'server',
-      status: viaP2P ? 'delivered' : 'pending',
+      status: viaP2P ? 'p2p' : 'pending',
       file: fileData || undefined,
     };
 

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -224,7 +224,7 @@ router.get(
 /**
  * GET /api/messages?chatWith={id}
  * Возвращает всю историю между текущим пользователем и chatWith,
- * а также помечает входящие pending-сообщения как delivered.
+ * а также помечает входящие сообщения как прочитанные.
  */
 router.get(
   '/messages',
@@ -247,15 +247,15 @@ router.get(
          FROM messages
         WHERE (sender_id = $1 AND receiver_id = $2)
            OR (sender_id = $2 AND receiver_id = $1)
-        ORDER BY timestamp ASC`,
+        ORDER BY timestamp DESC`,
         [userId, chatWith]
       );
       await db!.query(
         `UPDATE messages
-            SET status = 'delivered'
+            SET status = 'read'
           WHERE sender_id = $2
             AND receiver_id = $1
-            AND status = 'pending'`,
+            AND status <> 'read'`,
         [userId, chatWith]
       );
 
@@ -263,7 +263,7 @@ router.get(
         `DELETE FROM messages
           WHERE sender_id = $2
             AND receiver_id = $1
-            AND status = 'delivered'`,
+            AND status = 'read'`,
         [userId, chatWith]
       );
 


### PR DESCRIPTION
## Summary
- load messages in descending order from server
- mark messages as read when retrieved
- mark p2p messages with dedicated status
- display recent messages first and load more on scroll down

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`