### PR TITLE
Fix offline status API URL

### DIFF
--- a/client/src/hooks/useUserStatus.ts
+++ b/client/src/hooks/useUserStatus.ts
@@ -42,8 +42,12 @@ export function useUserStatusHeartbeat() {
     }, 10_000);
 
     const setOffline = () => {
+      const envBase = import.meta.env.VITE_API_URL || 'http://localhost:4000';
+      const base = envBase.endsWith('/api')
+        ? envBase
+        : `${envBase.replace(/\/+$/, '')}/api`;
       navigator.sendBeacon(
-        `${import.meta.env.VITE_API_URL}/api/users/status`,
+        `${base}/users/status`,
         JSON.stringify({ isonline: 0 })
       );
       queryClient.setQueryData(['/api/user'], (prev: any) =>


### PR DESCRIPTION
## Summary
- handle missing `VITE_API_URL` when sending user status beacon so that losing the connection no longer hits `undefined/api`

## Testing
- `pnpm run type-check`