### PR TITLE
Add selectable user position

### DIFF
--- a/build/shared/electron-shared/schema/users.js
+++ b/build/shared/electron-shared/schema/users.js
@@ -4,6 +4,7 @@ exports.departments = exports.insertUserSchema = exports.users = void 0;
 const pg_core_1 = require("drizzle-orm/pg-core");
 const zod_1 = require("zod");
 const departments_1 = require("./departments");
+const jobs_1 = require("./jobs");
 Object.defineProperty(exports, "departments", { enumerable: true, get: function () { return departments_1.departments; } });
 exports.users = (0, pg_core_1.pgTable)("users", {
     id: (0, pg_core_1.serial)("id").primaryKey(),
@@ -15,6 +16,7 @@ exports.users = (0, pg_core_1.pgTable)("users", {
     isOnline: (0, pg_core_1.integer)("isonline").default(0),
     avatarUrl: (0, pg_core_1.text)("avatarurl"),
     departmentId: (0, pg_core_1.integer)('department_id').references(() => departments_1.departments.id),
+    jobId: (0, pg_core_1.integer)('job_id').references(() => jobs_1.jobs.id),
     jobTitle: (0, pg_core_1.text)('job_title'),
     language: (0, pg_core_1.text)('language').default('en'),
     isAdmin: (0, pg_core_1.boolean)('is_admin').default(false).notNull(),

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -26,6 +26,7 @@ export interface UserWithoutPassword {
   email: string | null;
   firstName: string | null;
   lastName: string | null;
+  jobId?: number | null;
   jobTitle?: string | null;
   isAdmin?: number;
   isOnline: boolean | number;

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -90,6 +90,7 @@
     "location": "Location",
     "department": "Department",
     "position": "Position",
+    "selectPosition": "Select position",
     "currentPassword": "Current Password",
     "newPassword": "New Password"
   },

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -102,6 +102,7 @@
     "location": "Местоположение",
     "department": "Отдел",
     "position": "Должность",
+    "selectPosition": "Выберите должность",
     "currentPassword": "Текущий пароль",
     "newPassword": "Новый пароль"
   },

--- a/client/src/pages/contacts-section.tsx
+++ b/client/src/pages/contacts-section.tsx
@@ -130,7 +130,7 @@ export default function ContactsSection({ onStartCall, onOpenChat }: ContactsPro
                       {contact.firstName} {contact.lastName}
                     </h3>
                     <p className="text-sm text-gray-500">
-                      {getJobTitle(Number(contact.id))}
+                      {contact.jobTitle || getJobTitle(Number(contact.id))}
                     </p>
                   </div>
                 </div>

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -30,18 +30,46 @@ import { Input } from '@/components/ui/input';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon, ArrowLeft } from 'lucide-react';
 import { useLocation } from 'wouter';
+import { useAuth } from '@/hooks/use-auth';
 
 const SettingsPage: React.FC = () => {
   const { t } = useTranslations();
   const { theme, setTheme, language, setLanguage } = useSettings();
   const { toast } = useToast();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
   const [, setLocation] = useLocation();
   const [emailNotifications, setEmailNotifications] = React.useState(true);
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
+
+  const { data: jobs = [] } = useQuery<{ id: number; name: string }[]>({
+    queryKey: ['/api/jobs'],
+    queryFn: async () => (await fetch('/api/jobs', { credentials: 'include' }).then(r => r.json())) as { id: number; name: string }[],
+  });
+
+  const updateJob = useMutation({
+    mutationFn: async (jobId: number | null) => {
+      await fetch('/api/user/job', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ jobId }),
+      });
+    },
+    onSuccess: (_data, jobId) => {
+      queryClient.setQueryData(['/api/user'], (prev: any) =>
+        prev ? { ...prev, jobId, jobTitle: jobs.find(j => j.id === jobId)?.name ?? null } : prev
+      );
+      toast({ title: t('common.changesApplied') });
+    },
+    onError: (error: Error) => {
+      toast({ variant: 'destructive', title: error.message });
+    },
+  });
 
   const handleThemeChange = (value: 'light' | 'dark' | 'system') => {
     setTheme(value);
@@ -289,6 +317,23 @@ const SettingsPage: React.FC = () => {
             </CardHeader>
             <CardContent className="space-y-4">
               <p>{t('settings.accountSettings')}</p>
+              <div className="space-y-2">
+                <Label htmlFor="position">{t('profile.position')}</Label>
+                <Select
+                  value={user?.jobId ? String(user.jobId) : ''}
+                  onValueChange={(val) => updateJob.mutate(val ? Number(val) : null)}
+                >
+                  <SelectTrigger id="position">
+                    <SelectValue placeholder={t('profile.selectPosition')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">-</SelectItem>
+                    {jobs.map((j) => (
+                      <SelectItem key={j.id} value={String(j.id)}>{j.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <ChangePasswordForm />
             </CardContent>
           </Card>

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -6,6 +6,7 @@ export interface UserWithoutPassword {
   phone?: string;
   firstName: string | null;
   lastName: string | null;
+  jobId?: number | null;
   jobTitle?: string | null;
   isOnline: boolean | number;
   avatarUrl: string | null;

--- a/server/src/auth/routes.ts
+++ b/server/src/auth/routes.ts
@@ -32,6 +32,7 @@ router.post('/login', async (req, res) => {
        email,
        first_name AS "firstName",
        last_name  AS "lastName",
+       job_id     AS "jobId",
        job_title  AS "jobTitle",
        avatarurl  AS "avatarUrl",
        is_admin   AS "isAdmin",

--- a/server/src/lib/api/auth.ts
+++ b/server/src/lib/api/auth.ts
@@ -11,6 +11,7 @@ export async function login(usernameOrEmail: string, password: string) {
        password,
        first_name AS "firstName",
        last_name  AS "lastName",
+       job_id     AS "jobId",
        job_title  AS "jobTitle",
        avatarurl  AS "avatarUrl",
        is_admin   AS "isAdmin",

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -11,6 +11,7 @@ import { isAuthenticated } from '../middleware/auth'; // Уже есть
 import { broadcastStatus, sendChatMessage } from '../ws'; // Уже есть
 import { sendEmailNotification } from '../util/email';
 import departmentsRouter from './departments';
+import jobsRouter from './jobs';
 import wikiRouter from './wiki';
 import requestsRouter from './requests';
 
@@ -27,6 +28,7 @@ const fileStore = new Map<number, string>();
 
 const router = Router();
 router.use('/departments', isAuthenticated, departmentsRouter);
+router.use('/jobs', isAuthenticated, jobsRouter);
 router.use('/requests', isAuthenticated, requestsRouter);
 router.use('/wiki', isAuthenticated, wikiRouter);
 /**
@@ -90,6 +92,7 @@ router.get('/user', isAuthenticated, async (req: Request, res: Response) => {
          email,
          first_name AS "firstName",
          last_name  AS "lastName",
+         job_id     AS "jobId",
          job_title  AS "jobTitle",
          avatarurl  AS "avatarUrl",
          is_admin   AS "isAdmin",
@@ -153,6 +156,31 @@ router.post(
 );
 
 /**
+ * PATCH /api/user/job
+ * Update current user's job position.
+ * Body: { jobId: number | null }
+ */
+router.patch('/user/job', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const { jobId } = req.body as { jobId: number | null };
+    const userId = req.session.userId as number;
+    let title: string | null = null;
+    if (jobId) {
+      const { rows } = await db!.query<{ name: string }>(
+        'SELECT name FROM jobs WHERE id = $1',
+        [jobId]
+      );
+      title = rows[0]?.name ?? null;
+    }
+    await db!.query('UPDATE users SET job_id = $1, job_title = $2 WHERE id = $3', [jobId, title, userId]);
+    res.json({ success: true, jobId, jobTitle: title });
+  } catch (err) {
+    logger.error('Update job error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+/**
  * PATCH /api/users/status
  * Обновление online/offline статуса пользователя.
  * Тело: { isonline: 0|1 }
@@ -198,6 +226,8 @@ router.get(
         email: string;
         firstName: string;
         lastName: string;
+        jobId: number | null;
+        jobTitle: string | null;
         isonline: boolean;
       }>(
         `SELECT
@@ -206,6 +236,8 @@ router.get(
            email,
            first_name AS "firstName",
            last_name  AS "lastName",
+           job_id     AS "jobId",
+           job_title  AS "jobTitle",
            isonline
          FROM users
          WHERE id <> $1;`,

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -80,6 +80,7 @@ router.get('/user', async (req, res) => {
          email,
          first_name AS "firstName",
          last_name  AS "lastName",
+         job_id     AS "jobId",
          job_title  AS "jobTitle",
          avatarurl  AS "avatarUrl",
          is_admin   AS "isAdmin",

--- a/server/src/routes/jobs.ts
+++ b/server/src/routes/jobs.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { db } from '../db';
+
+const router = Router();
+
+// GET /api/jobs - list all job positions
+router.get('/', async (_req, res) => {
+  const { rows } = await db!.query('SELECT id, name FROM jobs ORDER BY name');
+  res.json(rows);
+});
+
+export default router;

--- a/shared/electron-shared/schema/users.ts
+++ b/shared/electron-shared/schema/users.ts
@@ -1,6 +1,7 @@
 import { pgTable, text, serial, integer, boolean } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { departments } from './departments';
+import { jobs } from './jobs';
 
 export const users = pgTable("users", {
   id: serial("id").primaryKey(),
@@ -12,6 +13,7 @@ export const users = pgTable("users", {
   isOnline: integer("isonline").default(0),
   avatarUrl: text("avatarurl"),
   departmentId: integer('department_id').references(() => departments.id),
+  jobId: integer('job_id').references(() => jobs.id),
   jobTitle: text('job_title'),
   language: text('language').default('en'),
   isAdmin: boolean('is_admin').default(false).notNull(),

--- a/shared/electron-shared/types.ts
+++ b/shared/electron-shared/types.ts
@@ -4,6 +4,7 @@ export interface UserWithoutPassword {
   lastName: string | null;
   email: string;
   phone?: string;
+  jobId?: number | null;
   jobTitle?: string | null;
   isonline?: number | boolean;
   isAdmin?: number;   // 0 | 1

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -12,6 +12,7 @@ export interface User {
   username: string;
   email: string;
   avatarUrl?: string | null;
+  jobId?: number | null;
   jobTitle?: string | null;
   isonline?: number | boolean;
 }

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -5,6 +5,7 @@ export interface UserWithoutPassword {
   firstName?: string;
   lastName?: string;
   phone?: string;
+  jobId?: number | null;
   jobTitle?: string | null;
   isonline?: number | boolean;
   isAdmin?: number;


### PR DESCRIPTION
## Summary
- add `jobId` field to user schema and types
- expose job titles in auth queries and contacts
- add API endpoint to update current user's job
- list job positions via `/api/jobs`
- allow choosing a position in settings
- show user job title in contacts list

## Testing
- `pnpm run type-check`