### PR TITLE
Add request acceptance

### DIFF
--- a/client/src/api/requests.ts
+++ b/client/src/api/requests.ts
@@ -14,6 +14,18 @@ export async function getRequests(): Promise<Request[]> {
   return res.json();
 }
 
+// Mark request as taken by current user
+export async function acceptRequest(requestId: number) {
+  const res = await fetch(`${BASE}/api/requests/${requestId}/accept`, {
+    method: 'PATCH',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error(`PATCH /api/requests/${requestId}/accept failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 // Handy helper you can use elsewhere if you want to mark a request “done”.
 export async function completeRequest(
   requestId: number,

--- a/client/src/pages/requests-section.tsx
+++ b/client/src/pages/requests-section.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PlusIcon, RefreshCw } from "lucide-react";
 import RequestModal from "./request-modal";
-import { getRequests } from "@/api/requests";
+import { getRequests, acceptRequest } from "@/api/requests";
 
 export interface Request {
   id: number;
@@ -36,6 +36,11 @@ export default function RequestsSection() {
     setLoading(true);
     setData(await getRequests());
     setLoading(false);
+  };
+
+  const handleAccept = async (id: number) => {
+    await acceptRequest(id);
+    load();
   };
 
   useEffect(() => { load(); }, []);
@@ -74,6 +79,16 @@ export default function RequestsSection() {
     { accessorKey: "cabinet", header: "Кабинет" },
     { accessorKey: "deadline", header: "Дедлайн" },
     { accessorKey: "grade", header: "Оценка" },
+    {
+      id: "actions",
+      header: "Действия",
+      cell: ({ row }) =>
+        row.original.status === "новая" ? (
+          <Button size="sm" onClick={() => handleAccept(row.original.id)}>
+            Принять
+          </Button>
+        ) : null,
+    },
   ];
 
   return (

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -46,6 +46,23 @@ router.post('/', async (req, res) => {
   }
 });
 
+// PATCH /api/requests/:id/accept – взять заявку в работу
+router.patch('/:id/accept', async (req, res) => {
+  const requestId = +req.params.id;
+  const userId = req.session.userId;
+
+  try {
+    const { rows } = await db!.query(
+      "UPDATE requests SET status = 'в работе', who_accepted = $1, taken_at = NOW() WHERE id = $2 RETURNING *",
+      [userId, requestId]
+    );
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Failed to accept request:', err);
+    res.status(500).json({ error: 'Failed to accept request' });
+  }
+});
+
 // PATCH /api/requests/:id/complete – пометить заявку выполненной (добавить отзыв, оценку)
 router.patch('/:id/complete', async (req, res) => {
   const requestId = +req.params.id;


### PR DESCRIPTION
## Summary
- implement request acceptance endpoint on the server
- expose `acceptRequest` helper in the client API
- show `Принять` button for new requests

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`