### PR TITLE
Increase JSON size limit

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -13,8 +13,8 @@ export async function createApp() {
   // core middleware
   app.use(morgan('dev'));
   app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
-  // Allow larger batched requests
-  app.use(express.json({ limit: '5mb' }));
+  // Allow larger batched requests and large file uploads
+  app.use(express.json({ limit: '50mb' }));
 
   // HTTP logging middleware
   app.use(pinoHttp({ logger, autoLogging: false }));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -34,8 +34,8 @@ export function createApp(): Express {
   /* ───────── COMMON MIDDLEWARE ───────── */
   app.use(pinoHttp({ logger: logger as any, autoLogging: false }));
   app.use(morgan('dev'));
-  // Increase JSON body size limit to handle batched messages
-  app.use(express.json({ limit: '5mb' }));
+  // Increase JSON body size limit to handle batched messages and large file uploads
+  app.use(express.json({ limit: '50mb' }));
   app.use(
     cors({
       origin: ['http://localhost:5173', 'app://.*'],


### PR DESCRIPTION
## Summary
- allow larger uploads by raising `express.json` limit to 50mb

## Testing
- `pnpm run type-check`
