### PR TITLE
Fix WS connection without auth

### DIFF
--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -30,6 +30,12 @@ export function useWebSocket() {
   useEffect(() => {
     let cancelled = false
 
+    if (!user) {
+      wsRef.current?.close()
+      setConnectionStatus('closed')
+      return
+    }
+
     const connect = () => {
       console.debug('WS connect attempt', retries.current)
       setConnectionStatus('connecting')


### PR DESCRIPTION
## Summary
- avoid connecting WebSocket before authentication

## Testing
- `pnpm run type-check`