### PR TITLE
Add P2P connectivity check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Tests are written with Jest and located in the `tests/` directory. Run them with
 pnpm exec jest
 ```
 
+To verify that WebRTC connectivity works in your environment run the P2P
+connection check script:
+
+```bash
+pnpm run check:p2p
+```
+
 ## Environment variables
 
 Copy `.env.example` to `.env` and fill in the required values before running the application.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:proxy": "node ./proxy.mjs",
     "rehash-passwords": "node ./scripts/rehash-passwords.cjs",
     "seed:dev": "node ./scripts/seed-dev-users.cjs",
+    "check:p2p": "node ./scripts/check-p2p.cjs",
     "type-check": "tsc -p shared/tsconfig.json && tsc -p client/tsconfig.json && tsc -p ./tsconfig.server.json"
   },
   "engines": {
@@ -82,6 +83,7 @@
     "path-to-regexp": "1.7.0",
     "pg": "latest",
     "pino-http": "^10.4.0",
+    "pnpm": "^10.11.0",
     "process": "^0.11.10",
     "react": "18.3.1",
     "react-day-picker": "^9.6.7",

--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+const SimplePeer = require('simple-peer');
+
+function createPeer(initiator) {
+  return new SimplePeer({
+    initiator,
+    trickle: false,
+    config: { iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] },
+  });
+}
+
+const peer1 = createPeer(true);
+const peer2 = createPeer(false);
+
+peer1.on('signal', data => peer2.signal(data));
+peer2.on('signal', data => peer1.signal(data));
+
+let success = false;
+
+peer1.on('connect', () => {
+  console.log('peer1 connected');
+  peer1.send('ping');
+});
+
+peer2.on('data', data => {
+  console.log('peer2 got:', data.toString());
+  if (data.toString() === 'ping') {
+    peer2.send('pong');
+  }
+});
+
+peer1.on('data', data => {
+  console.log('peer1 got:', data.toString());
+  if (data.toString() === 'pong') {
+    success = true;
+    console.log('P2P connection OK');
+    cleanup();
+  }
+});
+
+const timeout = setTimeout(() => {
+  console.error('P2P connection failed');
+  cleanup();
+}, 5000);
+
+function cleanup() {
+  clearTimeout(timeout);
+  peer1.destroy();
+  peer2.destroy();
+  if (!success) process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script `scripts/check-p2p.cjs` that verifies WebRTC connectivity using simple-peer
- expose `pnpm run check:p2p` npm script
- document the new script in README

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`