### PR TITLE
Improve p2p check script

### DIFF
--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -1,61 +1,69 @@
 #!/usr/bin/env node
 const { RTCPeerConnection } = require('werift-webrtc');
+const fs = require('fs');
+const path = require('path');
 
-async function run() {
-  const pc1 = new RTCPeerConnection({
-    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
-  });
+const stunListPath = path.join(__dirname, 'stun-servers.json');
+let stunServers = ['stun:stun.l.google.com:19302'];
+try {
+  const data = fs.readFileSync(stunListPath, 'utf8');
+  const list = JSON.parse(data);
+  if (Array.isArray(list) && list.length) stunServers = list;
+} catch {
+  console.warn('Using default STUN server list');
+}
+
+async function checkServer(stun) {
+  console.log(`Using STUN server: ${stun}`);
+  const pc1 = new RTCPeerConnection({ iceServers: [{ urls: stun }] });
   const pc2 = new RTCPeerConnection();
 
-  pc1.onicecandidate = ({ candidate }) => {
-    if (candidate) pc2.addIceCandidate(candidate);
-  };
-  pc2.onicecandidate = ({ candidate }) => {
-    if (candidate) pc1.addIceCandidate(candidate);
-  };
+  pc1.onicecandidate = ({ candidate }) => candidate && pc2.addIceCandidate(candidate);
+  pc2.onicecandidate = ({ candidate }) => candidate && pc1.addIceCandidate(candidate);
 
   const dc1 = pc1.createDataChannel('test');
-  let success = false;
 
-  dc1.onopen = () => {
-    console.log('peer1 connected');
-    dc1.send('ping');
-  };
-
-  dc1.onmessage = ({ data }) => {
-    console.log('peer1 got:', data);
-    if (data === 'pong') {
-      success = true;
-      console.log('P2P connection OK');
-      cleanup();
-    }
-  };
-
-  pc2.ondatachannel = ({ channel }) => {
-    channel.onmessage = ({ data }) => {
-      console.log('peer2 got:', data);
-      if (data === 'ping') channel.send('pong');
+  return await new Promise(async (resolve) => {
+    let success = false;
+    dc1.onopen = () => dc1.send('ping');
+    dc1.onmessage = ({ data }) => {
+      if (data === 'pong') {
+        success = true;
+        cleanup();
+      }
     };
-  };
+    pc2.ondatachannel = ({ channel }) => {
+      channel.onmessage = ({ data }) => {
+        if (data === 'ping') channel.send('pong');
+      };
+    };
 
-  const offer = await pc1.createOffer();
-  await pc1.setLocalDescription(offer);
-  await pc2.setRemoteDescription(offer);
-  const answer = await pc2.createAnswer();
-  await pc2.setLocalDescription(answer);
-  await pc1.setRemoteDescription(answer);
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription(offer);
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription(answer);
 
-  const timeout = setTimeout(() => {
-    console.error('P2P connection failed');
-    cleanup();
-  }, 5000);
+    const timeout = setTimeout(cleanup, 5000);
 
-  function cleanup() {
-    clearTimeout(timeout);
-    pc1.close();
-    pc2.close();
-    if (!success) process.exit(1);
+    function cleanup() {
+      clearTimeout(timeout);
+      pc1.close();
+      pc2.close();
+      resolve(success);
+    }
+  });
+}
+
+async function run() {
+  let allOk = true;
+  for (const stun of stunServers) {
+    const ok = await checkServer(stun);
+    console.log(`${stun} ${ok ? 'OK' : 'FAILED'}`);
+    if (!ok) allOk = false;
   }
+  if (!allOk) process.exit(1);
 }
 
 run();

--- a/scripts/stun-servers.json
+++ b/scripts/stun-servers.json
@@ -1,0 +1,8 @@
+[
+  "stun:stun.l.google.com:19302",
+  "stun:stun1.l.google.com:19302",
+  "stun:stun2.l.google.com:19302",
+  "stun:stun3.l.google.com:19302",
+  "stun:stun4.l.google.com:19302",
+  "stun:stun.nextcloud.com:443"
+]


### PR DESCRIPTION
## Summary
- test P2P connectivity against multiple STUN servers
- store STUN server list in `scripts/stun-servers.json`

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*