### PR TITLE
Fix P2P checker cleanup

### DIFF
--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -87,6 +87,12 @@ async function tryConnection(server) {
 
   function cleanup() {
     clearTimeout(timeout);
+    // Ensure the data channel closes so the promise resolves
+    try {
+      dc1.close();
+    } catch (_) {
+      // ignore errors if channel is not open
+    }
     pc1.close();
     pc2.close();
     if (success) {


### PR DESCRIPTION
## Summary
- ensure `check-p2p` closes the data channel so the promise resolves

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*