### PR TITLE
Fix P2P checker cleanup

### DIFF
--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -80,6 +80,18 @@ async function tryConnection(server) {
   await pc2.setLocalDescription(answer);
   await pc1.setRemoteDescription(answer);
 
+  let resolveDone;
+  const done = new Promise((resolve) => {
+    resolveDone = resolve;
+  });
+
+  let cleaned = false;
+  function finish() {
+    if (cleaned) return;
+    cleaned = true;
+    resolveDone(success);
+  }
+
   const timeout = setTimeout(() => {
     console.error('P2P connection timed out');
     cleanup();
@@ -87,18 +99,25 @@ async function tryConnection(server) {
 
   function cleanup() {
     clearTimeout(timeout);
+    try {
+      if (dc1.readyState !== 'closed') dc1.close();
+    } catch (_) {
+      // ignore errors if channel is not open
+    }
     pc1.close();
     pc2.close();
     if (success) {
       console.log('cleanup after success');
     }
+    finish();
   }
-  return new Promise((resolve) => {
-    dc1.onclose = () => {
-      console.log('peer1 data channel closed');
-      resolve(success);
-    };
-  });
+
+  dc1.onclose = () => {
+    console.log('peer1 data channel closed');
+    finish();
+  };
+
+  return done;
 }
 
 async function run() {


### PR DESCRIPTION
## Summary
- ensure `check-p2p` resolves after timeout by explicitly resolving the promise

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*
