### PR TITLE
Improve STUN connectivity script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ before moving on to the configured servers:
 STUN_SERVER=none pnpm run check:p2p
 ```
 
+The checker automatically appends `?transport=udp` to each STUN URL and prints
+ICE candidate types for easier debugging.
+
 ## Environment variables
 
 Copy `.env.example` to `.env` and fill in the required values before running the application.

--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -8,26 +8,43 @@ const STUN_LIST = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'stun-servers.json'), 'utf8'),
 );
 
+function addUdpTransport(url) {
+  if (!url) return url;
+  return url.includes('?') ? url : `${url}?transport=udp`;
+}
+
+const STUN_LIST_UDP = STUN_LIST.map(addUdpTransport);
+
 async function tryConnection(server) {
-  const iceServers = server ? [{ urls: server }] : [];
+  const iceServers = server ? [{ urls: addUdpTransport(server) }] : [];
   console.log(
     server ? `Using STUN server: ${server}` : 'Running without STUN server'
   );
 
   // give both peers the same configuration
-  const config = { iceServers };
+  const config = { iceServers, iceTransportPolicy: 'all' };
   const pc1 = new RTCPeerConnection(config);
   const pc2 = new RTCPeerConnection(config);
 
   pc1.onicecandidate = ({ candidate }) => {
     if (candidate) {
-      console.log('pc1 -> pc2 candidate', candidate.candidate);
+      console.log(
+        'pc1 -> pc2 candidate',
+        candidate.candidate,
+        'type',
+        candidate.type
+      );
       pc2.addIceCandidate(candidate);
     }
   };
   pc2.onicecandidate = ({ candidate }) => {
     if (candidate) {
-      console.log('pc2 -> pc1 candidate', candidate.candidate);
+      console.log(
+        'pc2 -> pc1 candidate',
+        candidate.candidate,
+        'type',
+        candidate.type
+      );
       pc1.addIceCandidate(candidate);
     }
   };
@@ -36,6 +53,10 @@ async function tryConnection(server) {
     console.log('pc1 state', pc1.connectionState);
   pc2.onconnectionstatechange = () =>
     console.log('pc2 state', pc2.connectionState);
+  pc1.onicegatheringstatechange = () =>
+    console.log('pc1 gathering', pc1.iceGatheringState);
+  pc2.onicegatheringstatechange = () =>
+    console.log('pc2 gathering', pc2.iceGatheringState);
 
   const dc1 = pc1.createDataChannel('test');
   let success = false;
@@ -97,9 +118,9 @@ async function run() {
   const serversToTry =
     STUN_SERVER !== undefined
       ? STUN_SERVER === 'none'
-        ? [null, ...STUN_LIST]
-        : [STUN_SERVER, ...STUN_LIST]
-      : STUN_LIST;
+        ? [null, ...STUN_LIST_UDP]
+        : [addUdpTransport(STUN_SERVER), ...STUN_LIST_UDP]
+      : STUN_LIST_UDP;
 
   for (const server of serversToTry) {
     const ok = await tryConnection(server);


### PR DESCRIPTION
## Summary
- log ICE candidate types and gathering state in `check-p2p.cjs`
- append `?transport=udp` to STUN URLs and force `iceTransportPolicy: 'all'`
- document new behaviour in README

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*