### PR TITLE
Fix P2P checker hang

### DIFF
--- a/scripts/check-p2p.cjs
+++ b/scripts/check-p2p.cjs
@@ -100,9 +100,17 @@ async function tryConnection() {
   await pc1.setLocalDescription(offer);
 
   await new Promise(resolve => {
-    if (pc1.iceGatheringState === 'complete') return resolve();
+    const timer = setTimeout(() => {
+      console.error('pc1 ICE gathering timed out');
+      resolve();
+    }, 5000);
+    if (pc1.iceGatheringState === 'complete') {
+      clearTimeout(timer);
+      return resolve();
+    }
     pc1.onicegatheringstatechange = () => {
       if (pc1.iceGatheringState === 'complete') {
+        clearTimeout(timer);
         console.log('pc1 ICE gathering complete');
         resolve();
       }


### PR DESCRIPTION
## Summary
- make the P2P connectivity checker bail after 5s of ICE gathering

## Testing
- `pnpm run type-check`
- `node scripts/check-p2p.cjs` *(fails: pc1 ICE gathering timed out / P2P connection timed out)*