### PR TITLE
Add local p2p flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,10 @@ Set `VITE_STUN_SERVER` in `.env` to override the STUN server used by the client
 for peer connections. Use `VITE_STUN_SERVER=none` to disable STUN entirely when
 both peers are on the same local network.
 
+During development you can pass `-localp2p` to `pnpm run dev` to temporarily
+disable STUN/TURN and force local peer discovery:
+
+```bash
+pnpm run dev -localp2p
+```
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "pnpm -r run build",
     "check-deps": "node tools/check-workspaces.cjs",
-    "dev": "concurrently -k -n server,client,electron -c green,blue,magenta \"pnpm run dev:server\" \"pnpm run dev:client\" \"pnpm run dev:electron\"",
+    "dev": "node ./scripts/run-dev.cjs",
     "dev:client": "pnpm --filter client run dev",
     "dev:debug": "cross-env NODE_OPTIONS=\"--inspect=9229\" pnpm run dev",
     "dev:electron": "pnpm --filter ccnew-electron run dev",

--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+const args = process.argv.slice(2);
+const flagIndex = args.indexOf('-localp2p');
+const flagIndex2 = args.indexOf('--localp2p');
+const local = flagIndex !== -1 || flagIndex2 !== -1;
+if (flagIndex !== -1) args.splice(flagIndex, 1);
+if (flagIndex2 !== -1) args.splice(flagIndex2, 1);
+
+const env = { ...process.env };
+if (local) {
+  env.VITE_STUN_SERVER = 'none';
+  env.STUN_SERVER = 'none';
+}
+
+const child = spawn(
+  'pnpm',
+  [
+    'exec',
+    'concurrently',
+    '-k',
+    '-n',
+    'server,client,electron',
+    '-c',
+    'green,blue,magenta',
+    'pnpm run dev:server',
+    'pnpm run dev:client',
+    'pnpm run dev:electron'
+  ],
+  { stdio: 'inherit', env }
+);
+
+child.on('exit', code => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary
- add `run-dev.cjs` helper to support `-localp2p` flag
- wire dev script to new helper
- document the flag in README

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`