### PR TITLE
Fix checklist issues

### DIFF
--- a/client/src/hooks/usePeerConnection.ts
+++ b/client/src/hooks/usePeerConnection.ts
@@ -27,14 +27,19 @@ export function usePeerConnection(
     if (!enabled) return;
     console.debug('P2P creating connection', { initiator });
     const stun = import.meta.env.VITE_STUN_SERVER;
-    const iceServers =
+    const turnUrl = import.meta.env.VITE_TURN_URL as string | undefined;
+    const turnUser = import.meta.env.VITE_TURN_USER as string | undefined;
+    const turnPass = import.meta.env.VITE_TURN_PASS as string | undefined;
+
+    const stunUrls =
       !stun || stun === 'none'
-        ? []
-        : stun
-            .split(',')
-            .map((url) => url.trim())
-            .filter(Boolean)
-            .map((url) => ({ urls: url }));
+        ? ['stun:stun.l.google.com:19302']
+        : stun.split(',').map((u) => u.trim()).filter(Boolean);
+
+    const iceServers: RTCIceServer[] = stunUrls.map((url) => ({ urls: url }));
+    if (turnUrl) {
+      iceServers.push({ urls: turnUrl, username: turnUser, credential: turnPass });
+    }
 
     const peer = new SimplePeer({
       initiator,
@@ -67,7 +72,7 @@ export function usePeerConnection(
     });
     peer.on('error', (err) => {
       console.error('P2P error', err);
-      setStatus('error');
+      setStatus('closed');
     });
 
     peerRef.current = peer;

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -26,6 +26,7 @@ export function useWebSocket() {
 
   const wsRef = useRef<WebSocket | null>(null)
   const retries = useRef(0)
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -63,7 +64,7 @@ export function useWebSocket() {
         if (!cancelled && retries.current < 5) {
           const backoff = Math.pow(2, retries.current) * 1000
           retries.current += 1
-          setTimeout(connect, backoff)
+          reconnectTimer.current = setTimeout(connect, backoff)
         }
       })
 
@@ -77,7 +78,17 @@ export function useWebSocket() {
 
     return () => {
       cancelled = true
-      wsRef.current?.close()
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current)
+        reconnectTimer.current = null
+      }
+      if (wsRef.current) {
+        wsRef.current.onopen = null
+        wsRef.current.onmessage = null
+        wsRef.current.onerror = null
+        wsRef.current.onclose = null
+        wsRef.current.close()
+      }
     }
   }, [user])
 

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -142,7 +142,7 @@ export default function AuthPage() {
     const registerMutation = useMutation({
       mutationFn: async (data: z.infer<typeof registerSchema>) => {
         const { confirmPassword, ...payload } = data;
-        const res = await fetch(`${import.meta.env.VITE_API_URL}/api/register`, {
+        const res = await fetch(`${baseURL}/api/register`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -150,7 +150,7 @@ export default function AuthPage() {
         });
         if (!res.ok) {
           const errorData = await res.json();
-          throw new Error(errorData.message || 'Registration failed');
+          throw new Error(errorData.error || 'Registration failed');
         }
         return await res.json();
       },

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -15,17 +15,14 @@ import jobsRouter from './jobs';
 import wikiRouter from './wiki';
 import requestsRouter from './requests';
 import adminRouter from './admin';
-
-interface SyncMessage {
-  id: number;
-  senderId: number;
-  receiverId: number;
-  content: string;
-  timestamp: string;
-}
-
-const syncStore = new Map<number, SyncMessage[]>();
-const fileStore = new Map<number, string>();
+import {
+  addSyncMessages,
+  takeSyncMessages,
+  storeFile,
+  getFile,
+  clearFile,
+  type SyncMessage,
+} from '../store/messageStore';
 
 const router = Router();
 router.use('/departments', isAuthenticated, departmentsRouter);
@@ -320,10 +317,11 @@ router.get(
       );
 
 
-      const withFiles = history.rows.map((m) => ({
-        ...m,
-        file: fileStore.get(m.id) ?? null,
-      }));
+      const withFiles = history.rows.map((m) => {
+        const f = getFile(m.id);
+        if (f) clearFile(m.id);
+        return { ...m, file: f ?? null };
+      });
       res.json(withFiles);
     } catch (err) {
       logger.error('GET /messages error:', err);
@@ -365,7 +363,7 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
       const name = `${message.id}.${ext}`;
       fs.writeFileSync(path.join(uploadDir, name), Buffer.from(base64Data, 'base64'));
       filePath = `/uploads/${name}`;
-      fileStore.set(message.id, filePath);
+      storeFile(message.id, filePath);
     }
 
     const delivered = sendChatMessage(receiverId, { ...message, file: filePath });
@@ -458,15 +456,13 @@ router.patch('/messages/:id', isAuthenticated, async (req: Request, res: Respons
 router.post('/sync/messages', isAuthenticated, (req: Request, res: Response) => {
   const userId = req.session.userId as number;
   const msgs = Array.isArray(req.body) ? (req.body as SyncMessage[]) : [];
-  if (!syncStore.has(userId)) syncStore.set(userId, []);
-  syncStore.get(userId)!.push(...msgs);
+  addSyncMessages(userId, msgs);
   res.json({ success: true });
 });
 
 router.get('/sync/messages', isAuthenticated, (req: Request, res: Response) => {
   const userId = req.session.userId as number;
-  const msgs = syncStore.get(userId) ?? [];
-  syncStore.set(userId, []);
+  const msgs = takeSyncMessages(userId);
   res.json(msgs);
 });
 

--- a/server/src/store/messageStore.ts
+++ b/server/src/store/messageStore.ts
@@ -1,0 +1,50 @@
+export interface SyncMessage {
+  id: number;
+  senderId: number;
+  receiverId: number;
+  content: string;
+  timestamp: string;
+}
+
+const syncStore = new Map<number, SyncMessage[]>();
+const fileStore = new Map<number, string>();
+const timers = new Map<string, NodeJS.Timeout>();
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function schedule<T>(store: Map<any, T>, key: any) {
+  const timerKey = `${store === fileStore ? 'f' : 's'}:${key}`;
+  const existing = timers.get(timerKey);
+  if (existing) clearTimeout(existing);
+  timers.set(
+    timerKey,
+    setTimeout(() => {
+      store.delete(key);
+      timers.delete(timerKey);
+    }, TTL_MS)
+  );
+}
+
+export function addSyncMessages(userId: number, msgs: SyncMessage[]) {
+  if (!syncStore.has(userId)) syncStore.set(userId, []);
+  syncStore.get(userId)!.push(...msgs);
+  schedule(syncStore, userId);
+}
+
+export function takeSyncMessages(userId: number): SyncMessage[] {
+  const msgs = syncStore.get(userId) ?? [];
+  syncStore.delete(userId);
+  return msgs;
+}
+
+export function storeFile(messageId: number, path: string) {
+  fileStore.set(messageId, path);
+  schedule(fileStore, messageId);
+}
+
+export function getFile(messageId: number): string | undefined {
+  return fileStore.get(messageId);
+}
+
+export function clearFile(messageId: number) {
+  fileStore.delete(messageId);
+}


### PR DESCRIPTION
## Summary
- clean up message/file stores with TTL
- improve WebSocket cleanup logic
- set default STUN server and support TURN credentials
- use base URL when registering and read `error` field

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`