### PR TITLE
Implement duplicate file checks

### DIFF
--- a/client/src/lib/message-storage.ts
+++ b/client/src/lib/message-storage.ts
@@ -5,6 +5,8 @@ export interface StoredMessage {
   content: string;
   timestamp: string;
   file?: string;
+  /** reference to message id that holds the actual file */
+  fileRef?: number;
   synced?: boolean;
   /** transport used to send the message */
   transport?: 'server' | 'p2p';
@@ -70,4 +72,12 @@ export function countUnreadMessages(myId: number, otherId: number): number {
 
 export function clearMessages(myId: number, otherId: number): void {
   localStorage.removeItem(key(myId, otherId));
+}
+
+export function findMessageByFile(
+  myId: number,
+  otherId: number,
+  file: string,
+): StoredMessage | undefined {
+  return loadMessages(myId, otherId).find((m) => m.file === file);
 }

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -13,6 +13,7 @@ import {
   StoredMessage,
   markMessagesRead,
   countUnreadMessages,
+  findMessageByFile,
 } from '@/lib/message-storage';
 import {
   Send,
@@ -49,6 +50,7 @@ export interface Message {
   synced?: boolean;
   error?: boolean;
   file?: string;
+  fileRef?: number;
 }
 
 export interface User {
@@ -285,6 +287,14 @@ export default function MessagesSection({ onStartCall }: Props) {
   const trimmedMessages = combinedMessages.slice(0, maxDisplay);
   const visibleMessages = trimmedMessages.slice(0, visibleCount).reverse();
 
+  const displayMessages = visibleMessages.map((m) => {
+    if (!m.file && (m as any).fileRef) {
+      const ref = combinedMessages.find((r) => r.id === (m as any).fileRef);
+      if (ref?.file) return { ...m, file: ref.file };
+    }
+    return m;
+  });
+
   useEffect(() => {
     setVisibleCount((c) => {
       const baseline = Math.min(pageSize, trimmedMessages.length);
@@ -313,6 +323,15 @@ export default function MessagesSection({ onStartCall }: Props) {
   const sendSingle = async (content: string, file?: string) => {
     const tempId = Date.now() + Math.random();
     const viaP2P = p2pStatus === 'open';
+
+    let fileRef: number | undefined;
+    if (file) {
+      const existing = findMessageByFile(user!.id, selectedUser!.id, file);
+      if (existing) {
+        fileRef = existing.id;
+        // don't store duplicate file locally
+      }
+    }
     if (viaP2P) {
       sendP2P({
         senderId: user!.id,
@@ -331,7 +350,8 @@ export default function MessagesSection({ onStartCall }: Props) {
       synced: viaP2P ? true : false,
       transport: viaP2P ? 'p2p' : 'server',
       status: viaP2P ? 'p2p' : 'pending',
-      file: file,
+      file: fileRef ? undefined : file,
+      fileRef,
     };
 
     appendMessage(user!.id, selectedUser!.id, tempMsg);
@@ -596,7 +616,7 @@ export default function MessagesSection({ onStartCall }: Props) {
                 {isLoadingMessages ? (
                   <Loader2 className="h-5 w-5 animate-spin" />
                 ) : (
-                  <MessageList messages={visibleMessages} myId={user.id} />
+                  <MessageList messages={displayMessages} myId={user.id} />
                 )}
               </div>
 


### PR DESCRIPTION
## Summary
- track file references in local message storage
- link to existing attachments instead of storing duplicates
- display messages using the referenced file

## Testing
- `pnpm exec jest` *(fails: command not found)*
- `pnpm run type-check` *(fails: command not found)*