### PR TITLE
Add P2P connection error toast

### DIFF
--- a/client/src/hooks/usePeerConnection.ts
+++ b/client/src/hooks/usePeerConnection.ts
@@ -73,7 +73,7 @@ export function usePeerConnection(
     });
     peer.on('error', (err) => {
       showError(err, 'P2P error');
-      setStatus('closed');
+      setStatus('error');
     });
 
     peerRef.current = peer;

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -197,6 +197,12 @@ export default function MessagesSection({ onStartCall }: Props) {
     !!selectedUser && selectedUser.isonline === 1,
   );
 
+  useEffect(() => {
+    if (p2pStatus === 'closed' || p2pStatus === 'error') {
+      showError(t('errors.connectionError'));
+    }
+  }, [p2pStatus, t]);
+
   /* ───── WS side‑effects ───── */
   useEffect(() => {
     if (!lastRawMessage) return;


### PR DESCRIPTION
## Summary
- surface P2P errors by keeping peer status 'error'
- notify user if peer connection closes unexpectedly

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
