### PR TITLE
Show server down banner with reload

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useElectron } from "./hooks/use-electron";
 import { useEffect, useState } from "react";
 import { showError } from "@/lib/error-toast";
 import { createApiClient } from "@/lib/api-client";
+import ServerDownBanner from "./components/server-down-banner";
 import { useUserStatusHeartbeat } from "./hooks/useUserStatus";
 
 function AppContent() {
@@ -60,8 +61,7 @@ function AppContent() {
 import { queryClient } from './lib/queryClient';
 
 export default function App() {
-  const [status, setStatus]   = useState('Loading...');
-  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('loading');
 
   const apiClient = createApiClient();
 
@@ -73,7 +73,6 @@ export default function App() {
 
     apiClient
       .request<{ message: string }>('/api/hello')
-      .then(data => setMessage(data?.message ?? ''))
       .catch(err => showError(err));
   }, [apiClient]);
 
@@ -83,11 +82,8 @@ export default function App() {
       <AuthProvider>
         <ChatProvider>
           <AppContent />
-          {status !== 'ok' && (
-            <div>
-              <h1>Server Status: {status}</h1>
-              <p>{message}</p>
-            </div>
+          {status === 'error' && (
+            <ServerDownBanner onReload={() => window.location.reload()} />
           )}
         </ChatProvider>
       </AuthProvider>

--- a/client/src/components/server-down-banner.tsx
+++ b/client/src/components/server-down-banner.tsx
@@ -1,0 +1,20 @@
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  onReload: () => void
+}
+
+export default function ServerDownBanner({ onReload }: Props) {
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-50 flex justify-center p-2">
+      <Alert variant="destructive" className="flex items-center gap-4 max-w-md">
+        <div>
+          <AlertTitle>Сервер не отвечает</AlertTitle>
+          <AlertDescription>Попробуйте обновить страницу</AlertDescription>
+        </div>
+        <Button onClick={onReload}>Перезагрузить страницу</Button>
+      </Alert>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `ServerDownBanner` component to display a message when the API is unreachable
- display the banner in `App` when `/api/health` fails

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
