### PR TITLE
Add phone validation

### DIFF
--- a/client/src/pages/request-modal.tsx
+++ b/client/src/pages/request-modal.tsx
@@ -228,6 +228,7 @@ export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
                   <FormControl>
                     <Input {...field} placeholder="Введите номер телефона" />
                   </FormControl>
+                  <FormMessage />
                 </FormItem>
               )}
             />

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { db } from '../db'; // Теперь этот импорт должен работать
+import { insertRequestSchema } from '@shared/schema';
 
 const router = Router();
 
@@ -15,7 +16,11 @@ router.get('/', async (req, res) => {
 
 // POST /api/requests – создать новую заявку
 router.post('/', async (req, res) => {
-  const { receiverDepartmentId, taskId, cabinet, phone, isUrgent, deadline, comment } = req.body;
+  const parseResult = insertRequestSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return res.status(400).json({ error: 'Invalid request data' });
+  }
+  const { receiverDepartmentId, taskId, cabinet, phone, isUrgent, deadline, comment } = parseResult.data;
   const senderId = req.session.userId;
 
   // Normalize optional fields. Empty strings should be stored as NULL to avoid

--- a/shared/electron-shared/schema/requests.ts
+++ b/shared/electron-shared/schema/requests.ts
@@ -37,7 +37,12 @@ export const insertRequestSchema = z.object({
   receiverDepartmentId: z.number(), // <-- изменено имя
   taskId: z.number(),
   cabinet: z.string().optional(),
-  phone: z.string().optional(),
+  phone: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\+?[0-9]{10,15}$/.test(val), {
+      message: 'Invalid phone number',
+    }),
   isUrgent: z.boolean().default(false),
   deadline: z.string().optional(),
   comment: z.string().optional(),

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -29,7 +29,12 @@ export const insertRequestSchema = z.object({
   receiverDepartmentId: z.number(),
   taskId: z.number(),
   cabinet: z.string().optional(),
-  phone: z.string().optional(),
+  phone: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\+?[0-9]{10,15}$/.test(val), {
+      message: 'Invalid phone number',
+    }),
   isUrgent: z.boolean().default(false),
   deadline: z.string().optional(),
   comment: z.string().optional(),


### PR DESCRIPTION
## Summary
- validate phone numbers in shared request schema
- use validation on the server before inserting a request
- show phone field errors in the request modal

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
