### PR TITLE
Add request management actions

### DIFF
--- a/client/src/api/requests.ts
+++ b/client/src/api/requests.ts
@@ -25,3 +25,20 @@ export async function completeRequest(
     body: JSON.stringify(payload),
   });
 }
+
+export async function updateRequest(
+  requestId: number,
+  data: Partial<
+    Pick<Request, 'cabinet' | 'phone' | 'isUrgent' | 'deadline' | 'comment'>
+  >
+) {
+  return api.request(`/requests/${requestId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteRequest(requestId: number) {
+  return api.request(`/requests/${requestId}`, { method: 'DELETE' });
+}

--- a/client/src/pages/request-modal.tsx
+++ b/client/src/pages/request-modal.tsx
@@ -33,6 +33,8 @@ import { useState, useEffect } from "react";
 import { insertRequestSchema } from "@shared/schema";
 import { z } from "zod";
 import { createApiClient } from "@/lib/api-client";
+import type { Request } from "./requests-section";
+import { updateRequest } from "@/api/requests";
 
 export type Department = {
   id: number;
@@ -50,13 +52,13 @@ interface RequestFormValues {
 }
 
 interface Props {
-  requests?: any[];
+  request?: Request;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
 }
 
-export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
+export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { user } = useAuth();
@@ -81,15 +83,25 @@ export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
 
   const form = useForm<RequestFormValues>({
     resolver: zodResolver(insertRequestSchema),
-    defaultValues: {
-      receiverDepartmentId: 0,
-      taskId: 0,
-      cabinet: '',
-      phone: '',
-      isUrgent: false,
-      deadline: '',
-      comment: ''
-    }
+    defaultValues: request
+      ? {
+          receiverDepartmentId: request.receiverDepartmentId,
+          taskId: request.taskId,
+          cabinet: request.cabinet ?? '',
+          phone: request.phone ?? '',
+          isUrgent: request.isUrgent,
+          deadline: request.deadline ?? '',
+          comment: request.comment ?? ''
+        }
+      : {
+          receiverDepartmentId: 0,
+          taskId: 0,
+          cabinet: '',
+          phone: '',
+          isUrgent: false,
+          deadline: '',
+          comment: ''
+        },
   });
 
   useEffect(() => {
@@ -105,25 +117,28 @@ export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
     }
   }, [departmentsError]);
 
-  const createRequest = useMutation({
+  const saveRequest = useMutation({
     mutationFn: async (data: RequestFormValues) => {
-        const payload = { ...data, creatorId: user?.id, /* ... */ };
-        const res = await apiClient.request("/api/requests", {
-          method: "POST",
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
+      const payload = { ...data, creatorId: user?.id };
+      if (request) {
+        return updateRequest(request.id, payload);
+      }
+      const res = await apiClient.request("/api/requests", {
+        method: "POST",
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
       return res;
     },
     onSuccess: () => {
-      toast({ title: "Заявка создана" });
+      toast({ title: request ? "Заявка обновлена" : "Заявка создана" });
       queryClient.invalidateQueries({ queryKey: ["/api/requests"] });
       onOpenChange(false);
       onSuccess();
     },
     onError: (err: any) =>
       toast({
-        title: "Не удалось создать заявку",
+        title: request ? "Не удалось обновить заявку" : "Не удалось создать заявку",
         description: err.message,
         variant: "destructive",
       }),
@@ -140,7 +155,7 @@ export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit((data) => createRequest.mutate(data))} className="space-y-4">
+          <form onSubmit={form.handleSubmit((data) => saveRequest.mutate(data))} className="space-y-4">
             <FormField
               control={form.control}
               name="receiverDepartmentId"
@@ -279,18 +294,18 @@ export function RequestModal({ open, onOpenChange, onSuccess }: Props) {
             <DialogFooter>
               <Button
                 type="submit"
-                disabled={createRequest.isPending}
+                disabled={saveRequest.isPending}
                 className="ml-auto"
               >
-                {createRequest.isPending ? (
+                {saveRequest.isPending ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Создание...
+                    {request ? 'Сохранение...' : 'Создание...'}
                   </>
                 ) : (
                   <>
                     <Plus className="mr-2 h-4 w-4" />
-                    Создать
+                    {request ? 'Сохранить' : 'Создать'}
                   </>
                 )}
               </Button>

--- a/client/src/pages/requests-section.tsx
+++ b/client/src/pages/requests-section.tsx
@@ -3,14 +3,21 @@ import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/ui/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { PlusIcon, RefreshCw } from "lucide-react";
+import { PlusIcon, RefreshCw, Trash2, Edit, Check } from "lucide-react";
 import RequestModal from "./request-modal";
-import { getRequests, acceptRequest } from "@/api/requests";
+import {
+  getRequests,
+  acceptRequest,
+  deleteRequest,
+  completeRequest,
+} from "@/api/requests";
+import { useAuth } from "@/hooks/use-auth";
 
 export interface Request {
   id: number;
+  senderId: number;
   status: 'новая' | 'в работе' | 'выполнена';
-  receiverSubdivisionId: number;
+  receiverDepartmentId: number;
   subdivision?: { id: number; name: string };
   taskId: number;
   task?: { id: number; name: string; category: string };
@@ -31,6 +38,8 @@ export default function RequestsSection() {
   const [data, setData] = useState<Request[]>([]);
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<Request | null>(null);
+  const { user } = useAuth();
 
   const load = async () => {
     setLoading(true);
@@ -40,6 +49,16 @@ export default function RequestsSection() {
 
   const handleAccept = async (id: number) => {
     await acceptRequest(id);
+    load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteRequest(id);
+    load();
+  };
+
+  const handleComplete = async (id: number) => {
+    await completeRequest(id, {});
     load();
   };
 
@@ -82,12 +101,37 @@ export default function RequestsSection() {
     {
       id: "actions",
       header: "Действия",
-      cell: ({ row }) =>
-        row.original.status === "новая" ? (
-          <Button size="sm" onClick={() => handleAccept(row.original.id)}>
-            Принять
-          </Button>
-        ) : null,
+      cell: ({ row }) => {
+        const r = row.original;
+        const canAccept = r.status === "новая" && user?.id !== r.senderId;
+        const canEdit = user?.id === r.senderId && r.status === "новая";
+        const canDelete = canEdit;
+        const canComplete = user?.id === r.senderId && r.status !== "выполнена";
+        return (
+          <div className="flex gap-2">
+            {canAccept && (
+              <Button size="sm" onClick={() => handleAccept(r.id)}>
+                Принять
+              </Button>
+            )}
+            {canEdit && (
+              <Button size="icon" variant="outline" onClick={() => { setEditing(r); setShowModal(true); }}>
+                <Edit className="h-4 w-4" />
+              </Button>
+            )}
+            {canDelete && (
+              <Button size="icon" variant="outline" onClick={() => handleDelete(r.id)}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+            {canComplete && (
+              <Button size="icon" variant="outline" onClick={() => handleComplete(r.id)}>
+                <Check className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        );
+      },
     },
   ];
 
@@ -107,7 +151,15 @@ export default function RequestsSection() {
 
       <DataTable columns={columns} data={data} placeholder="Заявок нет"/>
 
-      <RequestModal open={showModal} onOpenChange={setShowModal} onSuccess={load}/>
+      <RequestModal
+        open={showModal}
+        request={editing ?? undefined}
+        onOpenChange={(o) => {
+          setShowModal(o);
+          if (!o) setEditing(null);
+        }}
+        onSuccess={load}
+      />
     </div>
   );
 }

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -7,7 +7,26 @@ const router = Router();
 router.get('/', async (req, res) => {
   const userId = req.session.userId;
   const { rows } = await db!.query(
-    'SELECT * FROM requests WHERE sender_id = $1 OR receiver_department_id IN (SELECT department_id FROM users WHERE id = $1)',
+    `SELECT
+       id,
+       sender_id              AS "senderId",
+       receiver_department_id AS "receiverDepartmentId",
+       task_id                AS "taskId",
+       cabinet,
+       phone,
+       is_urgent              AS "isUrgent",
+       deadline,
+       comment,
+       who_accepted           AS "whoAccepted",
+       taken_at               AS "takenAt",
+       grade,
+       review_text            AS "reviewText",
+       finished_at            AS "finishedAt",
+       status,
+       created_at             AS "createdAt"
+     FROM requests
+    WHERE sender_id = $1
+       OR receiver_department_id IN (SELECT department_id FROM users WHERE id = $1)`,
     [userId]
   );
   res.json(rows);
@@ -66,11 +85,82 @@ router.patch('/:id/accept', async (req, res) => {
 // PATCH /api/requests/:id/complete – пометить заявку выполненной (добавить отзыв, оценку)
 router.patch('/:id/complete', async (req, res) => {
   const requestId = +req.params.id;
+  const userId = req.session.userId;
   const { grade, reviewText } = req.body;
-  const { rows } = await db!.query(
-    'UPDATE requests SET grade = $1, review_text = $2, status = \'готово\', finished_at = NOW() WHERE id = $3 RETURNING *',
-    [grade, reviewText, requestId]
-  );
-  res.json(rows[0]);
+  try {
+    const check = await db!.query('SELECT sender_id FROM requests WHERE id = $1', [requestId]);
+    if (check.rows[0]?.sender_id !== userId) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const { rows } = await db!.query(
+      "UPDATE requests SET grade = $1, review_text = $2, status = 'готово', finished_at = NOW() WHERE id = $3 RETURNING *",
+      [grade, reviewText, requestId]
+    );
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Failed to complete request:', err);
+    res.status(500).json({ error: 'Failed to complete request' });
+  }
+});
+
+// PATCH /api/requests/:id – обновить существующую заявку
+router.patch('/:id', async (req, res) => {
+  const requestId = +req.params.id;
+  const userId = req.session.userId;
+  const { cabinet, phone, isUrgent, deadline, comment } = req.body;
+
+  const sanitizedCabinet = cabinet || null;
+  const sanitizedPhone = phone || null;
+  const sanitizedDeadline = deadline || null;
+  const sanitizedComment = comment || null;
+
+  try {
+    const { rows } = await db!.query(
+      `UPDATE requests
+          SET cabinet = $1,
+              phone = $2,
+              is_urgent = $3,
+              deadline = $4,
+              comment = $5
+        WHERE id = $6 AND sender_id = $7
+        RETURNING *`,
+      [
+        sanitizedCabinet,
+        sanitizedPhone,
+        isUrgent ?? false,
+        sanitizedDeadline,
+        sanitizedComment,
+        requestId,
+        userId,
+      ]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Failed to update request:', err);
+    res.status(500).json({ error: 'Failed to update request' });
+  }
+});
+
+// DELETE /api/requests/:id – удалить заявку
+router.delete('/:id', async (req, res) => {
+  const requestId = +req.params.id;
+  const userId = req.session.userId;
+
+  try {
+    const { rows } = await db!.query(
+      'DELETE FROM requests WHERE id = $1 AND sender_id = $2 RETURNING *',
+      [requestId, userId]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Failed to delete request:', err);
+    res.status(500).json({ error: 'Failed to delete request' });
+  }
 });
 export default router;


### PR DESCRIPTION
## Summary
- support editing and deleting requests via API
- allow marking request completed only by creator
- expose update and delete helpers in API client
- update RequestModal to edit existing requests
- show actions in requests table

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
