### PR TITLE
Improve attachment deduplication

### DIFF
--- a/client/src/lib/message-storage.ts
+++ b/client/src/lib/message-storage.ts
@@ -7,6 +7,8 @@ export interface StoredMessage {
   file?: string;
   /** reference to message id that holds the actual file */
   fileRef?: number;
+  /** stable hash of the file for deduplication */
+  fileHash?: string;
   synced?: boolean;
   /** transport used to send the message */
   transport?: 'server' | 'p2p';
@@ -80,4 +82,21 @@ export function findMessageByFile(
   file: string,
 ): StoredMessage | undefined {
   return loadMessages(myId, otherId).find((m) => m.file === file);
+}
+
+export function findMessageByHash(
+  myId: number,
+  otherId: number,
+  hash: string,
+): StoredMessage | undefined {
+  return loadMessages(myId, otherId).find((m) => m.fileHash === hash);
+}
+
+export async function computeFileHash(data: string): Promise<string> {
+  const enc = new TextEncoder();
+  const buf = enc.encode(data);
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -13,7 +13,8 @@ import {
   StoredMessage,
   markMessagesRead,
   countUnreadMessages,
-  findMessageByFile,
+  findMessageByHash,
+  computeFileHash,
 } from '@/lib/message-storage';
 import {
   Send,
@@ -51,6 +52,7 @@ export interface Message {
   error?: boolean;
   file?: string;
   fileRef?: number;
+  fileHash?: string;
 }
 
 export interface User {
@@ -331,8 +333,14 @@ export default function MessagesSection({ onStartCall }: Props) {
     const viaP2P = p2pStatus === 'open';
 
     let fileRef: number | undefined;
+    let fileHash: string | undefined;
     if (file) {
-      const existing = findMessageByFile(user!.id, selectedUser!.id, file);
+      fileHash = await computeFileHash(file);
+      const existing = findMessageByHash(
+        user!.id,
+        selectedUser!.id,
+        fileHash,
+      );
       if (existing) {
         fileRef = existing.id;
         // не сохраняем локально дубликаты файла
@@ -358,6 +366,7 @@ export default function MessagesSection({ onStartCall }: Props) {
       status: viaP2P ? 'p2p' : 'pending',
       file: fileRef ? undefined : file,
       fileRef,
+      fileHash,
     };
 
     appendMessage(user!.id, selectedUser!.id, tempMsg);
@@ -377,8 +386,9 @@ export default function MessagesSection({ onStartCall }: Props) {
         if (!saved) return;
 
         const updated: StoredMessage = {
+          ...tempMsg,
           ...saved,
-          file: (saved.file ?? file) || undefined,
+          file: (saved.file ?? file) || tempMsg.file,
           synced: true,
           transport: 'server',
           status: saved.status,


### PR DESCRIPTION
## Summary
- add `fileHash` field to `StoredMessage`
- compute SHA-256 hash for files and check for duplicates via hash
- preserve hash when updating sent messages

## Testing
- `pnpm run type-check`