### PR TITLE
Handle uploaded image reuse and trim empty chat messages

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -47,7 +47,9 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
     }
   }, [messages]);
 
-  if (messages.length === 0) {
+  const filtered = messages.filter((m) => m.content.trim() !== '' || !!m.file);
+
+  if (filtered.length === 0) {
     return <p className="text-gray-500 dark:text-gray-400 text-sm">{t('messages.noMessages')}</p>;
   }
 
@@ -78,7 +80,7 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
 
   return (
     <div className="min-h-full flex flex-col space-y-3">
-      {messages.map((m) => (
+      {filtered.map((m) => (
         <div
           key={m.id}
           className={`max-w-[80%] rounded-xl px-4 py-2 text-sm break-words space-y-2 ${

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -366,15 +366,20 @@ router.post('/messages', isAuthenticated, async (req: Request, res: Response) =>
     const message = insert.rows[0];
     let filePath: string | undefined;
     if (file) {
-      const uploadDir = path.join(process.cwd(), 'uploads');
-      await fsp.mkdir(uploadDir, { recursive: true });
-      const extMatch = /^data:(.*?);base64/.exec(file);
-      const ext = extMatch ? extMatch[1].split('/')[1] || 'bin' : 'bin';
-      const base64Data = file.replace(/^data:.*;base64,/, '');
-      const name = `${message.id}.${ext}`;
-      await fsp.writeFile(path.join(uploadDir, name), Buffer.from(base64Data, 'base64'));
-      filePath = `/uploads/${name}`;
-      storeFile(message.id, filePath);
+      if (file.startsWith('/uploads/')) {
+        filePath = file;
+        storeFile(message.id, filePath);
+      } else {
+        const uploadDir = path.join(process.cwd(), 'uploads');
+        await fsp.mkdir(uploadDir, { recursive: true });
+        const extMatch = /^data:(.*?);base64/.exec(file);
+        const ext = extMatch ? extMatch[1].split('/')[1] || 'bin' : 'bin';
+        const base64Data = file.replace(/^data:.*;base64,/, '');
+        const name = `${message.id}.${ext}`;
+        await fsp.writeFile(path.join(uploadDir, name), Buffer.from(base64Data, 'base64'));
+        filePath = `/uploads/${name}`;
+        storeFile(message.id, filePath);
+      }
     }
 
     const delivered = sendChatMessage(receiverId, { ...message, file: filePath });
@@ -537,15 +542,20 @@ router.post('/groups/:groupId/messages', isAuthenticated, async (req: Request, r
     const message = insert.rows[0];
     let filePath: string | undefined;
     if (file) {
-      const uploadDir = path.join(process.cwd(), 'uploads');
-      await fsp.mkdir(uploadDir, { recursive: true });
-      const extMatch = /^data:(.*?);base64/.exec(file);
-      const ext = extMatch ? extMatch[1].split('/')[1] || 'bin' : 'bin';
-      const base64Data = file.replace(/^data:.*;base64,/, '');
-      const name = `${message.id}.${ext}`;
-      await fsp.writeFile(path.join(uploadDir, name), Buffer.from(base64Data, 'base64'));
-      filePath = `/uploads/${name}`;
-      storeFile(message.id, filePath);
+      if (file.startsWith('/uploads/')) {
+        filePath = file;
+        storeFile(message.id, filePath);
+      } else {
+        const uploadDir = path.join(process.cwd(), 'uploads');
+        await fsp.mkdir(uploadDir, { recursive: true });
+        const extMatch = /^data:(.*?);base64/.exec(file);
+        const ext = extMatch ? extMatch[1].split('/')[1] || 'bin' : 'bin';
+        const base64Data = file.replace(/^data:.*;base64,/, '');
+        const name = `${message.id}.${ext}`;
+        await fsp.writeFile(path.join(uploadDir, name), Buffer.from(base64Data, 'base64'));
+        filePath = `/uploads/${name}`;
+        storeFile(message.id, filePath);
+      }
     }
 
     const { rows } = await db!.query<{ user_id: number }>(


### PR DESCRIPTION
## Summary
- filter out chat messages with no text or file before rendering
- treat `/uploads/*` paths as existing images when posting messages to the API

## Testing
- `pnpm run type-check`
