### PR TITLE
Fix WebSocket reconnect loop

### DIFF
--- a/client/src/hooks/useUserStatus.ts
+++ b/client/src/hooks/useUserStatus.ts
@@ -10,7 +10,7 @@ export function useUserStatusHeartbeat() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!user) return;
+    if (!user?.id) return;
     // сразу помечаем online
     apiClient
       .request('/users/status', {
@@ -64,5 +64,5 @@ export function useUserStatusHeartbeat() {
       setOffline();
       window.removeEventListener('beforeunload', setOffline);
     };
-  }, [user, queryClient]);
+  }, [user?.id, queryClient]);
 }


### PR DESCRIPTION
## Summary
- avoid re-running the user status heartbeat when user data changes

## Testing
- `pnpm run type-check`
- `pnpm exec jest` *(fails: Command "jest" not found)*