### PR TITLE
Remove duplicate mobile header

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -100,8 +100,7 @@ export default function Sidebar({
         )}
       >
         {/* Mobile close button */}
-        <div className="flex items-center justify-between p-4 md:hidden">
-          <h2 className="text-xl font-semibold text-primary-600">Nexus</h2>
+        <div className="flex items-center justify-end p-4 md:hidden">
           <Button variant="ghost" size="icon" onClick={() => setIsOpen(false)}>
             <XIcon className="h-5 w-5" />
           </Button>


### PR DESCRIPTION
## Summary
- remove the `Nexus` heading inside the mobile sidebar close button to avoid overlapping headers

## Testing
- `pnpm run type-check`
