### PR TITLE
Fix image retrieval after dedup cleanup

### DIFF
--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -23,6 +23,7 @@ import {
   storeFile,
   getFile,
   clearFile,
+  findStoredFilePath,
   type SyncMessage,
 } from '../store/messageStore';
 
@@ -329,8 +330,12 @@ router.get(
 
 
       const withFiles = history.rows.map((m) => {
-        const f = getFile(m.id);
-        if (f) clearFile(m.id);
+        let f = getFile(m.id);
+        if (!f) {
+          f = findStoredFilePath(m.id);
+        } else {
+          clearFile(m.id);
+        }
         return { ...m, file: f ?? null };
       });
       res.json(withFiles);
@@ -511,8 +516,12 @@ router.get('/groups/:groupId/messages', isAuthenticated, async (req: Request, re
     );
 
     const withFiles = history.rows.map((m) => {
-      const f = getFile(m.id);
-      if (f) clearFile(m.id);
+      let f = getFile(m.id);
+      if (!f) {
+        f = findStoredFilePath(m.id);
+      } else {
+        clearFile(m.id);
+      }
       return { ...m, file: f ?? null };
     });
     res.json(withFiles);

--- a/server/src/store/messageStore.ts
+++ b/server/src/store/messageStore.ts
@@ -1,3 +1,7 @@
+
+import fs from 'fs';
+import path from 'path';
+
 export interface SyncMessage {
   id: number;
   senderId: number;
@@ -47,4 +51,15 @@ export function getFile(messageId: number): string | undefined {
 
 export function clearFile(messageId: number) {
   fileStore.delete(messageId);
+}
+
+export function findStoredFilePath(messageId: number): string | undefined {
+  try {
+    const uploadDir = path.join(process.cwd(), 'uploads');
+    const files = fs.readdirSync(uploadDir);
+    const name = files.find((f) => f.startsWith(`${messageId}.`));
+    return name ? `/uploads/${name}` : undefined;
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary
- keep uploads available after in-memory cache expires
- check filesystem when serving messages

## Testing
- `pnpm run type-check`