### PR TITLE
Fix ws cleanup & peer signalling

### DIFF
--- a/client/src/hooks/usePeerConnection.ts
+++ b/client/src/hooks/usePeerConnection.ts
@@ -88,7 +88,9 @@ export function usePeerConnection(
     if (incomingSignal && peerRef.current) {
       console.debug('P2P received signal', incomingSignal);
       try {
-        peerRef.current.signal(incomingSignal);
+        if (!peerRef.current.destroyed) {
+          peerRef.current.signal(incomingSignal);
+        }
       } catch (err) {
         showError(err, 'P2P signal error');
       }
@@ -96,9 +98,10 @@ export function usePeerConnection(
   }, [incomingSignal]);
 
   const send = (msg: PeerMessage) => {
-    if (enabled && peerRef.current?.connected) {
+    const peer = peerRef.current;
+    if (enabled && peer && peer.connected && !peer.destroyed) {
       console.debug('P2P send', msg);
-      peerRef.current.send(JSON.stringify(msg));
+      peer.send(JSON.stringify(msg));
     }
   };
 

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -98,7 +98,11 @@ export function useWebSocket() {
         wsRef.current.onmessage = null
         wsRef.current.onerror = null
         wsRef.current.onclose = null
-        wsRef.current.close()
+        if (wsRef.current.readyState === WebSocket.CONNECTING) {
+          wsRef.current.addEventListener('open', () => wsRef.current?.close())
+        } else {
+          wsRef.current.close()
+        }
       }
     }
   }, [user])


### PR DESCRIPTION
## Summary
- prevent calling signal on destroyed peer connections
- close websocket cleanly if it's still connecting

## Testing
- `pnpm run type-check`
