### PR TITLE
Add request detail dialog

### DIFF
--- a/client/src/components/ui/data-table.tsx
+++ b/client/src/components/ui/data-table.tsx
@@ -1,5 +1,6 @@
 import {
   ColumnDef,
+  Row,
   flexRender,
   getCoreRowModel,
   getPaginationRowModel,
@@ -21,12 +22,14 @@ interface DataTableProps<TData> {
   columns: ColumnDef<TData, any>[];
   data: TData[];
   placeholder?: string;
+  onRowClick?: (row: Row<TData>) => void;
 }
 
 export function DataTable<TData>({
   columns,
   data,
   placeholder = "No data",
+  onRowClick,
 }: DataTableProps<TData>) {
   const table = useReactTable({
     data,
@@ -66,7 +69,12 @@ export function DataTable<TData>({
 
         <TableBody>
           {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+            <TableRow
+              key={row.id}
+              data-state={row.getIsSelected() && "selected"}
+              onClick={() => onRowClick?.(row)}
+              className={onRowClick ? "cursor-pointer" : undefined}
+            >
               {row.getVisibleCells().map((cell) => (
                 <TableCell key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/client/src/pages/request-details-dialog.tsx
+++ b/client/src/pages/request-details-dialog.tsx
@@ -1,0 +1,78 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Request } from "./requests-section";
+import { useAuth } from "@/hooks/use-auth";
+import { deleteRequest } from "@/api/requests";
+import { useToast } from "@/hooks/use-toast";
+
+interface Props {
+  request: Request | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEdit: (req: Request) => void;
+  onDeleted: () => void;
+}
+
+export default function RequestDetailsDialog({ request, open, onOpenChange, onEdit, onDeleted }: Props) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const handleDelete = async () => {
+    if (!request) return;
+    try {
+      await deleteRequest(request.id);
+      toast({ title: "Заявка удалена" });
+      onOpenChange(false);
+      onDeleted();
+    } catch (err: any) {
+      toast({ title: "Ошибка удаления", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Заявка #{request?.id}</DialogTitle>
+          <DialogDescription>Детали заявки</DialogDescription>
+        </DialogHeader>
+        {request && (
+          <div className="space-y-2">
+            {request.createdAt && (
+              <p><span className="font-medium">Дата:</span> {new Date(request.createdAt).toLocaleString()}</p>
+            )}
+            {request.task?.name && (
+              <p><span className="font-medium">Задание:</span> {request.task.name}</p>
+            )}
+            {request.cabinet && (
+              <p><span className="font-medium">Кабинет:</span> {request.cabinet}</p>
+            )}
+            {request.phone && (
+              <p><span className="font-medium">Телефон:</span> {request.phone}</p>
+            )}
+            {request.deadline && (
+              <p><span className="font-medium">Выполнить до:</span> {new Date(request.deadline).toLocaleString()}</p>
+            )}
+            {request.comment && (
+              <p><span className="font-medium">Комментарий:</span> {request.comment}</p>
+            )}
+            {request.status && (
+              <p><span className="font-medium">Статус:</span> {request.status}</p>
+            )}
+            {request.whoAccepted && (
+              <p><span className="font-medium">Принял заявку:</span> {request.whoAccepted.firstName} {request.whoAccepted.lastName}</p>
+            )}
+          </div>
+        )}
+        <DialogFooter className="mt-4">
+          {request && user?.id === request.senderId && (
+            <>
+              <Button variant="outline" onClick={() => onEdit(request)}>Редактировать</Button>
+              <Button variant="destructive" onClick={handleDelete}>Удалить</Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/requests-section.tsx
+++ b/client/src/pages/requests-section.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PlusIcon, RefreshCw, Trash2, Edit, Check } from "lucide-react";
 import RequestModal from "./request-modal";
+import RequestDetailsDialog from "./request-details-dialog";
 import {
   getRequests,
   acceptRequest,
@@ -39,6 +40,7 @@ export default function RequestsSection() {
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [editing, setEditing] = useState<Request | null>(null);
+  const [selected, setSelected] = useState<Request | null>(null);
   const { user } = useAuth();
 
   const load = async () => {
@@ -60,6 +62,10 @@ export default function RequestsSection() {
   const handleComplete = async (id: number) => {
     await completeRequest(id, {});
     load();
+  };
+
+  const handleRowClick = (row: Request) => {
+    setSelected(row);
   };
 
   useEffect(() => { load(); }, []);
@@ -149,7 +155,12 @@ export default function RequestsSection() {
         </div>
       </div>
 
-      <DataTable columns={columns} data={data} placeholder="Заявок нет"/>
+      <DataTable
+        columns={columns}
+        data={data}
+        placeholder="Заявок нет"
+        onRowClick={(row) => handleRowClick(row.original)}
+      />
 
       <RequestModal
         open={showModal}
@@ -159,6 +170,19 @@ export default function RequestsSection() {
           if (!o) setEditing(null);
         }}
         onSuccess={load}
+      />
+
+      <RequestDetailsDialog
+        open={selected !== null}
+        request={selected}
+        onOpenChange={(o) => {
+          if (!o) setSelected(null);
+        }}
+        onEdit={(r) => {
+          setEditing(r);
+          setShowModal(true);
+        }}
+        onDeleted={load}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- add row click support in `DataTable`
- show request details in a new dialog
- integrate details view into requests section

## Testing
- `pnpm run type-check`
