### PR TITLE
Fix Markdown editor ref

### DIFF
--- a/client/src/components/wiki/markdown-editor.tsx
+++ b/client/src/components/wiki/markdown-editor.tsx
@@ -1,37 +1,43 @@
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Textarea } from '@/components/ui/textarea';
+import { Textarea, type TextareaProps } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MarkdownPreview } from './markdown-preview';
 
-interface MarkdownEditorProps {
+interface MarkdownEditorProps
+  extends Omit<TextareaProps, 'onChange'> {
   value: string;
   onChange: (value: string) => void;
   className?: string;
 }
 
-export function MarkdownEditor({ value, onChange, className }: MarkdownEditorProps) {
-  const [tab, setTab] = useState('write');
-  const { t } = useTranslation();
+export const MarkdownEditor = forwardRef<HTMLTextAreaElement, MarkdownEditorProps>(
+  ({ value, onChange, className, ...props }, ref) => {
+    const [tab, setTab] = useState('write');
+    const { t } = useTranslation();
 
-  return (
-    <Tabs value={tab} onValueChange={setTab} className={className}>
-      <TabsList>
-        <TabsTrigger value="write">{t('common.write', 'Write')}</TabsTrigger>
-        <TabsTrigger value="preview">{t('common.preview', 'Preview')}</TabsTrigger>
-      </TabsList>
-      <TabsContent value="write">
-        <Textarea
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          className="min-h-[250px]"
-        />
-      </TabsContent>
-      <TabsContent value="preview">
-        <div className="border rounded-md p-2 min-h-[250px] overflow-auto">
-          <MarkdownPreview content={value} />
-        </div>
-      </TabsContent>
-    </Tabs>
-  );
-}
+    return (
+      <Tabs value={tab} onValueChange={setTab} className={className}>
+        <TabsList>
+          <TabsTrigger value="write">{t('common.write', 'Write')}</TabsTrigger>
+          <TabsTrigger value="preview">{t('common.preview', 'Preview')}</TabsTrigger>
+        </TabsList>
+        <TabsContent value="write">
+          <Textarea
+            ref={ref}
+            value={value}
+            onChange={e => onChange(e.target.value)}
+            className="min-h-[250px]"
+            {...props}
+          />
+        </TabsContent>
+        <TabsContent value="preview">
+          <div className="border rounded-md p-2 min-h-[250px] overflow-auto">
+            <MarkdownPreview content={value} />
+          </div>
+        </TabsContent>
+      </Tabs>
+    );
+  },
+);
+MarkdownEditor.displayName = 'MarkdownEditor';


### PR DESCRIPTION
## Summary
- forward ref through `MarkdownEditor` so `FormControl` can attach props

## Testing
- `pnpm run type-check`