### PR TITLE
Fix datetime picker parse error

### DIFF
--- a/client/src/components/ui/datetime-picker.tsx
+++ b/client/src/components/ui/datetime-picker.tsx
@@ -55,7 +55,8 @@ const DateTimePicker = React.forwardRef<HTMLInputElement, DateTimePickerProps>(
       />
     </div>
   )
-}
+  }
+)
 
 DateTimePicker.displayName = "DateTimePicker"
 


### PR DESCRIPTION
## Summary
- close forwardRef call in `DateTimePicker`

## Testing
- `pnpm exec jest` *(fails: command not found)*
- `pnpm run type-check` *(fails: command not found)*