### PR TITLE
Fix auto scroll threshold

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -40,7 +40,7 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
     const container = endRef.current?.parentElement;
     if (!container) return;
     const nearBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight < 50;
+      container.scrollHeight - container.scrollTop - container.clientHeight < 10;
     if (nearBottom) {
       endRef.current?.scrollIntoView({ behavior: 'smooth' });
     }


### PR DESCRIPTION
## Summary
- adjust nearBottom threshold in MessageList to prevent aggressive auto-scroll

## Testing
- `pnpm exec jest` *(fails: command not found)*
- `pnpm run type-check` *(fails: command not found)*