### PR TITLE
Implement desktop notifications

### DIFF
--- a/client/src/lib/desktop-notify.ts
+++ b/client/src/lib/desktop-notify.ts
@@ -1,0 +1,16 @@
+import { showError } from './error-toast';
+
+export async function showDesktopNotification(title: string, options?: NotificationOptions) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  try {
+    if (Notification.permission === 'default') {
+      await Notification.requestPermission();
+    }
+    if (Notification.permission === 'granted') {
+      const n = new Notification(title, options);
+      setTimeout(() => n.close(), 5000);
+    }
+  } catch (err) {
+    showError(err, 'Notification error');
+  }
+}

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { SectionType } from "@/types/sections";
 import { useChat } from "@/context/ChatContext";
 import { useMessageSync } from "@/hooks/useMessageSync";
+import { showDesktopNotification } from "@/lib/desktop-notify";
 
 export default function HomePage() {
   const [activeSection, setActiveSection] = useState<SectionType>("messages");
@@ -145,6 +146,9 @@ export default function HomePage() {
       if (msg.senderId === user.id) return;
       if (chatUser && msg.senderId === chatUser.id) return;
       toast({ title: t('messages.newMessage'), description: msg.content });
+      if (!document.hasFocus()) {
+        showDesktopNotification(t('messages.newMessage'), { body: msg.content });
+      }
       return;
     }
 
@@ -159,6 +163,11 @@ export default function HomePage() {
         name: payload.fromName,
         callType: payload.callType,
       });
+      if (!document.hasFocus()) {
+        showDesktopNotification(payload.fromName, {
+          body: t(`call.${payload.callType}`),
+        });
+      }
     }
 
     if (lastRawMessage.type === 'p2p-signal') {


### PR DESCRIPTION
## Summary
- add helper to show system notifications
- trigger notifications for new messages and incoming calls

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`