### PR TITLE
Implement basic admin user management

### DIFF
--- a/client/src/pages/admin-page.tsx
+++ b/client/src/pages/admin-page.tsx
@@ -18,6 +18,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useEffect, useMemo, useState } from 'react';
 import { createApiClient } from '@/lib/api-client';
+import { showError } from '@/lib/error-toast';
+import { Checkbox } from '@/components/ui/checkbox';
 
 export default function AdminPage() {
   const { user } = useAuth();
@@ -32,6 +34,8 @@ export default function AdminPage() {
   const [result, setResult] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const apiClient = createApiClient();
+
+  const [users, setUsers] = useState<any[]>([]);
 
   const [newUser, setNewUser] = useState({
     username: '',
@@ -49,9 +53,20 @@ export default function AdminPage() {
         setTables(data?.tables ?? []);
       } catch (err) {
         setError((err as Error).message);
+        showError(err);
       }
     }
     fetchTables();
+
+    async function fetchUsers() {
+      try {
+        const data = await apiClient.request<{ users: any[] }>('/api/admin/users');
+        setUsers(data?.users ?? []);
+      } catch (err) {
+        showError(err);
+      }
+    }
+    fetchUsers();
   }, []);
 
   useEffect(() => {
@@ -65,6 +80,7 @@ export default function AdminPage() {
         setRows([]);
         setEditedRows([]);
         setError((err as Error).message);
+        showError(err);
       }
     }
     fetchRows();
@@ -94,6 +110,7 @@ export default function AdminPage() {
       });
     } catch (err) {
       setError((err as Error).message);
+      showError(err);
     }
   }
 
@@ -109,6 +126,7 @@ export default function AdminPage() {
     } catch (err) {
       setResult([]);
       setError((err as Error).message);
+      showError(err);
     }
   }
 
@@ -129,8 +147,24 @@ export default function AdminPage() {
         password: '',
         isAdmin: false,
       });
+      const data = await apiClient.request<{ users: any[] }>('/api/admin/users');
+      setUsers(data?.users ?? []);
     } catch (err) {
       setError((err as Error).message);
+      showError(err);
+    }
+  }
+
+  async function setUserAdmin(id: number, isAdmin: boolean) {
+    try {
+      await apiClient.request(`/api/admin/users/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isAdmin }),
+      });
+      setUsers(prev => prev.map(u => (u.id === id ? { ...u, isAdmin } : u)));
+    } catch (err) {
+      showError(err);
     }
   }
 
@@ -208,6 +242,41 @@ export default function AdminPage() {
               </label>
               <Button type="submit">Create</Button>
             </form>
+          </CardContent>
+        </Card>
+
+        <Card className="space-y-4">
+          <CardHeader>
+            <CardTitle>User Management</CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-auto">
+            <table className="min-w-full divide-y divide-border">
+              <thead className="bg-primary-100 dark:bg-primary-900/30">
+                <tr>
+                  <th className="px-3 py-2 text-left text-sm font-semibold">ID</th>
+                  <th className="px-3 py-2 text-left text-sm font-semibold">Username</th>
+                  <th className="px-3 py-2 text-left text-sm font-semibold">Email</th>
+                  <th className="px-3 py-2 text-center text-sm font-semibold">Admin</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {users.map(u => (
+                  <tr key={u.id} className="odd:bg-background">
+                    <td className="px-3 py-2">{u.id}</td>
+                    <td className="px-3 py-2">{u.username}</td>
+                    <td className="px-3 py-2">{u.email}</td>
+                    <td className="px-3 py-2 text-center">
+                      <Checkbox
+                        checked={u.isAdmin}
+                        onCheckedChange={checked =>
+                          setUserAdmin(u.id, checked === true)
+                        }
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </CardContent>
         </Card>
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -112,4 +112,52 @@ router.post('/table/:name', isAuthenticated, async (req: Request, res: Response)
   }
 });
 
+// GET /api/admin/users - list all users
+router.get('/users', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const userId = req.session.userId as number;
+    const { rows } = await db!.query<{ is_admin: boolean }>(
+      'SELECT is_admin FROM users WHERE id = $1',
+      [userId],
+    );
+    if (!rows[0]?.is_admin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const result = await db!.query(
+      `SELECT id, username, email, first_name AS "firstName", last_name AS "lastName", job_title AS "jobTitle", is_admin AS "isAdmin", isonline AS "isOnline" FROM users ORDER BY id`,
+    );
+    res.json({ users: result.rows });
+  } catch (err) {
+    logger.error('Admin users list error:', err);
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// PATCH /api/admin/users/:id - update user fields (currently only isAdmin)
+router.patch('/users/:id', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const adminId = req.session.userId as number;
+    const { rows } = await db!.query<{ is_admin: boolean }>(
+      'SELECT is_admin FROM users WHERE id = $1',
+      [adminId],
+    );
+    if (!rows[0]?.is_admin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const id = Number(req.params.id);
+    const { isAdmin } = req.body as { isAdmin?: boolean };
+    if (!id || typeof isAdmin !== 'boolean') {
+      return res.status(400).json({ error: 'Invalid request' });
+    }
+
+    await db!.query('UPDATE users SET is_admin = $1 WHERE id = $2', [isAdmin ? 1 : 0, id]);
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Admin user update error:', err);
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- extend admin API with `/api/admin/users` list and update endpoints
- show all users in admin panel with ability to toggle admin flag
- display errors via `showError`

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`