### PR TITLE
Add optional Python WS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ disable STUN/TURN and force local peer discovery:
 pnpm run dev -localp2p
 ```
 
+Pass `-pyws` to additionally start the experimental Python WebSocket server:
+
+```bash
+pnpm run dev -pyws
+```
+

--- a/python_ws_server.py
+++ b/python_ws_server.py
@@ -1,0 +1,23 @@
+import asyncio
+from fastapi import FastAPI, WebSocket
+import uvicorn
+import argparse
+
+app = FastAPI()
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            data = await ws.receive_text()
+            await ws.send_text(data)
+    except Exception:
+        pass
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simple Python WebSocket echo server")
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind")
+    parser.add_argument("--port", type=int, default=8001, help="Port to bind")
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -7,6 +7,9 @@ const flagIndex2 = args.indexOf('--localp2p');
 const local = flagIndex !== -1 || flagIndex2 !== -1;
 if (flagIndex !== -1) args.splice(flagIndex, 1);
 if (flagIndex2 !== -1) args.splice(flagIndex2, 1);
+const pywsIndex = args.indexOf('-pyws');
+const pyws = pywsIndex !== -1;
+if (pywsIndex !== -1) args.splice(pywsIndex, 1);
 
 const env = { ...process.env };
 if (local) {
@@ -14,6 +17,19 @@ if (local) {
   env.STUN_SERVER = 'none';
 }
 
+const names = ['server', 'client', 'electron'];
+const colors = ['green', 'blue', 'magenta'];
+const commands = [
+  'pnpm run dev:server',
+  'pnpm run dev:client',
+  'pnpm run dev:electron'
+];
+
+if (pyws) {
+  names.push('pyws');
+  colors.push('yellow');
+  commands.push('python3 python_ws_server.py');
+}
 const child = spawn(
   'pnpm',
   [
@@ -21,12 +37,10 @@ const child = spawn(
     'concurrently',
     '-k',
     '-n',
-    'server,client,electron',
+    names.join(','),
     '-c',
-    'green,blue,magenta',
-    'pnpm run dev:server',
-    'pnpm run dev:client',
-    'pnpm run dev:electron'
+    colors.join(','),
+    ...commands
   ],
   { stdio: 'inherit', env }
 );


### PR DESCRIPTION
## Summary
- add basic python WebSocket server
- support `-pyws` flag in run-dev script to start python server
- document new flag in README

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`