### PR TITLE
Add pyws flag to disable Node WS

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ disable STUN/TURN and force local peer discovery:
 pnpm run dev -localp2p
 ```
 
-Pass `-pyws` to additionally start the experimental Python WebSocket server:
+Pass `-pyws` to start the experimental Python WebSocket server instead of the
+built‑in Node WebSocket implementation. When this flag is used the Node WS
+server will not start:
 
 ```bash
 pnpm run dev -pyws

--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -16,6 +16,9 @@ if (local) {
   env.VITE_STUN_SERVER = 'none';
   env.STUN_SERVER = 'none';
 }
+if (pyws) {
+  env.NO_NODE_WS = '1';
+}
 
 const names = ['server', 'client', 'electron'];
 const colors = ['green', 'blue', 'magenta'];

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,8 +16,12 @@ async function main() {
   // Оборачиваем Express в HTTP-сервер
   const server = http.createServer(app);
 
-  // Инициализируем WS сессией
-  initWebSocket(server, sessionMiddleware);
+  // Инициализируем WS сессией, если не выключено флагом
+  if (!process.env.NO_NODE_WS) {
+    initWebSocket(server, sessionMiddleware);
+  } else {
+    logger.info('NO_NODE_WS set, skipping built-in WebSocket server');
+  }
 
   server.listen(config.port, () => {
     logger.info(`🚀 Server ready on http://localhost:${config.port}`);


### PR DESCRIPTION
## Summary
- start the Python WebSocket server without the Node WS server when using `-pyws`
- document the new behaviour

## Testing
- `pnpm run type-check` *(fails: `pnpm: command not found`)*