### PR TITLE
Improve pyws support on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains a monorepo setup for a corporate messaging application.
 
 - Node.js 20 or later
 - [pnpm](https://pnpm.io/) package manager
+- Python 3 (required only when using the `-pyws` flag)
 
 ## Getting started
 
@@ -97,4 +98,5 @@ server will not start:
 ```bash
 pnpm run dev -pyws
 ```
+On Windows the script uses `py -3` to launch Python automatically.
 

--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -31,7 +31,8 @@ const commands = [
 if (pyws) {
   names.push('pyws');
   colors.push('yellow');
-  commands.push('python3 python_ws_server.py');
+  const pythonCmd = process.platform === 'win32' ? 'py -3' : 'python3';
+  commands.push(`${pythonCmd} python_ws_server.py`);
 }
 const child = spawn(
   'pnpm',


### PR DESCRIPTION
## Summary
- run the Python WebSocket server with `py -3` on Windows
- document Python 3 requirement and Windows behaviour in README

## Testing
- `pnpm run type-check`
