### PR TITLE
Resolve Pylance and TS errors

### DIFF
--- a/python_ws_server.py
+++ b/python_ws_server.py
@@ -41,9 +41,13 @@ def update_online_status(user_id: int, isonline: int) -> None:
 async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
     params = ws.query_params
+    user_id_param = params.get("userId")
+    if user_id_param is None:
+        await ws.close(code=4401)
+        return
     try:
-        user_id = int(params.get("userId"))
-    except (TypeError, ValueError):
+        user_id = int(user_id_param)
+    except ValueError:
         await ws.close(code=4401)
         return
     user_set = connections.setdefault(user_id, set())

--- a/scripts/auto-wrap.ts
+++ b/scripts/auto-wrap.ts
@@ -18,7 +18,8 @@ module.exports = function transformer(file: FileInfo, api: API) {
       const name =
         decl.type === 'FunctionDeclaration'
           ? decl.id!.name
-          : (decl.declarations[0].id as any).name;
+          : ((decl.declarations[0] as j.VariableDeclarator).id as j.Identifier)
+              .name;
 
       const wrapCall = j.callExpression(j.identifier('withLogging'), [j.identifier(name)]);
       const newDecl =


### PR DESCRIPTION
## Summary
- fix websocket userId parsing logic
- refine auto-wrap typings for VariableDeclarator

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`