### PR TITLE
Fix types in auto-wrap script

### DIFF
--- a/scripts/auto-wrap.ts
+++ b/scripts/auto-wrap.ts
@@ -1,4 +1,4 @@
-import { API, FileInfo } from 'jscodeshift';
+import type { API, FileInfo, Identifier, VariableDeclarator } from 'jscodeshift';
 
 module.exports = function transformer(file: FileInfo, api: API) {
   const j = api.jscodeshift;
@@ -18,8 +18,7 @@ module.exports = function transformer(file: FileInfo, api: API) {
       const name =
         decl.type === 'FunctionDeclaration'
           ? decl.id!.name
-          : ((decl.declarations[0] as j.VariableDeclarator).id as j.Identifier)
-              .name;
+          : ((decl.declarations[0] as VariableDeclarator).id as Identifier).name;
 
       const wrapCall = j.callExpression(j.identifier('withLogging'), [j.identifier(name)]);
       const newDecl =


### PR DESCRIPTION
## Summary
- import Identifier and VariableDeclarator types
- update casts to use the imported types

## Testing
- `pnpm run type-check`
