### PR TITLE
Fix pyws dev env WebSocket URL

### DIFF
--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -18,6 +18,9 @@ if (local) {
 }
 if (pyws) {
   env.NO_NODE_WS = '1';
+  if (!env.VITE_WS_URL) {
+    env.VITE_WS_URL = 'ws://localhost:8001/ws';
+  }
 }
 
 const names = ['server', 'client', 'electron'];


### PR DESCRIPTION
## Summary
- set `VITE_WS_URL` automatically when using `-pyws`

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
