### PR TITLE
Improve chat scrolling and p2p updates

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -34,6 +34,7 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
   const { t } = useTranslation();
   const endRef = useRef<HTMLDivElement | null>(null);
   const prevMessagesRef = useRef<string | null>(null);
+  const firstRenderRef = useRef(true);
   const [viewerSrc, setViewerSrc] = useState<string | null>(null);
 
   useEffect(() => {
@@ -41,9 +42,11 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
     if (!container) return;
     const nearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight < 10;
-    if (nearBottom) {
-      endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const behavior = firstRenderRef.current ? 'auto' : 'smooth';
+    if (nearBottom || firstRenderRef.current) {
+      endRef.current?.scrollIntoView({ behavior });
     }
+    if (firstRenderRef.current) firstRenderRef.current = false;
   }, [messages]);
 
   useEffect(() => {

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -275,8 +275,9 @@ export default function MessagesSection({ onStartCall }: Props) {
         saveMessages(user!.id, selectedUser!.id, updated);
         return updated;
       });
+      refetchHistory();
     }
-  }, [p2pMsg, selectedUser, user]);
+  }, [p2pMsg, selectedUser, user, refetchHistory]);
 
   /* ───── helpers ───── */
   const getInitials = (f: string, l: string) =>


### PR DESCRIPTION
## Summary
- ensure chat scrolls to bottom immediately without animation
- refresh history when P2P message is received

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`