### PR TITLE
Fix real-time chat when using Python WS

### DIFF
--- a/python_ws_server.py
+++ b/python_ws_server.py
@@ -4,6 +4,8 @@ import json
 from typing import Dict, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Body
+from typing import List
 import uvicorn
 
 # Map user_id -> set of WebSocket connections
@@ -32,6 +34,20 @@ async def broadcast_status(user_id: int, isonline: int) -> None:
         for ws in sets:
             if ws.client_state.name == "CONNECTED":
                 await ws.send_text(msg)
+
+# ----- HTTP endpoints for server-side message delivery -----
+@app.post("/chat")
+async def post_chat(userId: int = Body(...), message: dict = Body(...)):
+    ok = await send_to_user(userId, {"type": "chat", "payload": message})
+    return {"delivered": ok}
+
+@app.post("/group-chat")
+async def post_group_chat(userIds: List[int] = Body(...), message: dict = Body(...)):
+    delivered = []
+    for uid in userIds:
+        if await send_to_user(uid, {"type": "chat", "payload": message}):
+            delivered.append(uid)
+    return {"delivered": delivered}
 
 def update_online_status(user_id: int, isonline: int) -> None:
     """Placeholder for updating DB user status."""

--- a/server/src/ws.ts
+++ b/server/src/ws.ts
@@ -158,16 +158,27 @@ export function sendChatMessage(
   receiverId: number,
   message: any,
 ): boolean {
-  const ok = sendToUser(receiverId, {
-    type: 'chat',
-    payload: message,
-  });
-  if (!ok) {
-    logger.debug(`Chat recipient ${receiverId} offline, skipping WS send`);
+  if (process.env.NO_NODE_WS) {
+    const wsUrl = process.env.VITE_WS_URL || 'ws://localhost:8001/ws';
+    const base = wsUrl.replace(/^ws/, 'http').replace(/\/ws$/, '');
+    fetch(`${base}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: receiverId, message }),
+    }).catch((err) => logger.error('pyws chat send failed:', err));
+    return false;
   } else {
-    logger.debug(`Sending chat message from ${message.senderId} to ${receiverId}`);
+    const ok = sendToUser(receiverId, {
+      type: 'chat',
+      payload: message,
+    });
+    if (!ok) {
+      logger.debug(`Chat recipient ${receiverId} offline, skipping WS send`);
+    } else {
+      logger.debug(`Sending chat message from ${message.senderId} to ${receiverId}`);
+    }
+    return ok;
   }
-  return ok;
 }
 
 /**
@@ -177,12 +188,23 @@ export function sendGroupMessage(
   receiverIds: number[],
   message: any,
 ): number[] {
-  const delivered: number[] = [];
-  for (const id of receiverIds) {
-    if (sendChatMessage(id, message)) {
-      delivered.push(id);
+  if (process.env.NO_NODE_WS) {
+    const wsUrl = process.env.VITE_WS_URL || 'ws://localhost:8001/ws';
+    const base = wsUrl.replace(/^ws/, 'http').replace(/\/ws$/, '');
+    fetch(`${base}/group-chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userIds: receiverIds, message }),
+    }).catch((err) => logger.error('pyws group send failed:', err));
+    return [];
+  } else {
+    const delivered: number[] = [];
+    for (const id of receiverIds) {
+      if (sendChatMessage(id, message)) {
+        delivered.push(id);
+      }
     }
+    return delivered;
   }
-  return delivered;
 }
 


### PR DESCRIPTION
## Summary
- extend Python WebSocket server with endpoints for sending chat messages
- forward chat and group messages to the Python WS when NO_NODE_WS is set

## Testing
- `pnpm run type-check`