### PR TITLE
Fix duplicate Jitsi frame

### DIFF
--- a/client/src/components/jitsi-frame.tsx
+++ b/client/src/components/jitsi-frame.tsx
@@ -32,8 +32,17 @@ export default function JitsiFrame({
         roomName,
         parentNode: containerRef.current,
         userInfo: { displayName: userName },
-        configOverwrite: { startWithVideoMuted: !video },
-        interfaceConfigOverwrite: { TOOLBAR_BUTTONS: [], ...interfaceConfig },
+        configOverwrite: {
+          startWithVideoMuted: !video,
+          prejoinPageEnabled: false,
+        },
+        interfaceConfigOverwrite: {
+          TOOLBAR_BUTTONS: [],
+          filmStripOnly: false,
+          SHOW_JITSI_WATERMARK: false,
+          SHOW_WATERMARK_FOR_GUESTS: false,
+          ...interfaceConfig,
+        },
       };
       const api = new (window as any).JitsiMeetExternalAPI(domain, options);
       onApiReady?.(api);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -18,9 +18,7 @@ import { SettingsProvider } from './context/SettingsContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <SettingsProvider>
-      <App />
-    </SettingsProvider>
-  </StrictMode>,
+  <SettingsProvider>
+    <App />
+  </SettingsProvider>,
 );


### PR DESCRIPTION
## Summary
- remove React StrictMode to avoid mounting Jitsi twice
- hide Jitsi's built‑in interface and prejoin page

## Testing
- `pnpm run type-check`
