### PR TITLE
Fix Jitsi script load

### DIFF
--- a/client/src/components/jitsi-frame.tsx
+++ b/client/src/components/jitsi-frame.tsx
@@ -67,6 +67,7 @@ export default function JitsiFrame({
           const script = document.createElement('script');
           script.src = 'https://meet.jit.si/external_api.js';
           script.async = true;
+          script.crossOrigin = 'anonymous';
           script.onload = () => resolve();
           script.onerror = () => reject(new Error('Failed to load Jitsi'));
           document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- load `external_api.js` with `crossOrigin='anonymous'` to avoid blocked requests

## Testing
- `pnpm run type-check`
