### PR TITLE
Fix Jitsi script loading

### DIFF
--- a/client/src/components/jitsi-frame.tsx
+++ b/client/src/components/jitsi-frame.tsx
@@ -67,7 +67,6 @@ export default function JitsiFrame({
           const script = document.createElement('script');
           script.src = 'https://meet.jit.si/external_api.js';
           script.async = true;
-          script.crossOrigin = 'anonymous';
           script.onload = () => resolve();
           script.onerror = () => reject(new Error('Failed to load Jitsi'));
           document.body.appendChild(script);


### PR DESCRIPTION
## Summary
- fix CORS issue when loading Jitsi external API by removing `crossOrigin` attribute

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
