### PR TITLE
Remove unsupported speaker-selection feature

### DIFF
--- a/client/src/components/jitsi-frame.tsx
+++ b/client/src/components/jitsi-frame.tsx
@@ -56,6 +56,13 @@ export default function JitsiFrame({
         },
       };
       api = new (window as any).JitsiMeetExternalAPI(domain, options);
+      const iframe = containerRef.current?.querySelector('iframe');
+      if (iframe) {
+        const allow = iframe.getAttribute('allow') ?? '';
+        if (allow.includes('speaker-selection')) {
+          iframe.setAttribute('allow', allow.replace(/\bspeaker-selection;?/g, ''));
+        }
+      }
       onApiReady?.(api);
     };
 


### PR DESCRIPTION
## Summary
- sanitize Jitsi iframe `allow` attribute to remove the unsupported `speaker-selection` feature

## Testing
- `pnpm run type-check`
