### PR TITLE
Add audio device selection

### DIFF
--- a/client/src/components/call-modal.tsx
+++ b/client/src/components/call-modal.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { createApiClient } from "@/lib/api-client";
 import { showError } from "@/lib/error-toast";
 import JitsiFrame from "./jitsi-frame";
+import { useSettings } from "@/context/SettingsContext";
 
 export type TranslationKey =
   | "call.video"
@@ -59,6 +60,7 @@ export default function CallModal({
   const [callLogId, setCallLogId] = useState<number | null>(null);
   const { t } = useTranslations();
   const { user } = useAuth();
+  const { audioInputId, audioOutputId } = useSettings();
   const apiClient = createApiClient();
   const startLog = async () => {
     try {
@@ -112,6 +114,24 @@ export default function CallModal({
       jitsiApi.removeEventListener('screenSharingStatusChanged', handleScreen);
     };
   }, [jitsiApi]);
+
+  useEffect(() => {
+    if (!jitsiApi) return;
+    if (audioInputId) {
+      try {
+        jitsiApi.setAudioInputDevice(audioInputId);
+      } catch (err) {
+        console.warn('Failed to set audio input device', err);
+      }
+    }
+    if (audioOutputId) {
+      try {
+        jitsiApi.setAudioOutputDevice(audioOutputId);
+      } catch (err) {
+        console.warn('Failed to set audio output device', err);
+      }
+    }
+  }, [jitsiApi, audioInputId, audioOutputId]);
 
   useEffect(() => {
     return () => {

--- a/client/src/context/SettingsContext.tsx
+++ b/client/src/context/SettingsContext.tsx
@@ -8,9 +8,11 @@ interface SettingsContextType {
   theme: Theme;
   language: string;
   audioInputId: string | null;
+  audioOutputId: string | null;
   setTheme: (theme: Theme) => void;
   setLanguage: (lang: string) => Promise<void>;
   setAudioInputId: (id: string | null) => void;
+  setAudioOutputId: (id: string | null) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -29,11 +31,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('system');
   const [language, setLanguageState] = useState<string>(i18n.language || 'en');
   const [audioInputId, setAudioInputIdState] = useState<string | null>(null);
+  const [audioOutputId, setAudioOutputIdState] = useState<string | null>(null);
 
   useEffect(() => {
     const storedTheme = localStorage.getItem('theme') as Theme | null;
     const storedLang = localStorage.getItem('language');
     const storedAudio = localStorage.getItem('audioInputId');
+    const storedOutput = localStorage.getItem('audioOutputId');
     if (storedTheme) {
       setThemeState(storedTheme);
       applyTheme(storedTheme);
@@ -44,6 +48,9 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     }
     if (storedAudio) {
       setAudioInputIdState(storedAudio);
+    }
+    if (storedOutput) {
+      setAudioOutputIdState(storedOutput);
     }
   }, []);
 
@@ -65,15 +72,23 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     else localStorage.removeItem('audioInputId');
   };
 
+  const setAudioOutputId = (id: string | null) => {
+    setAudioOutputIdState(id);
+    if (id) localStorage.setItem('audioOutputId', id);
+    else localStorage.removeItem('audioOutputId');
+  };
+
   return (
     <SettingsContext.Provider
       value={{
         theme,
         language,
         audioInputId,
+        audioOutputId,
         setTheme,
         setLanguage,
         setAudioInputId,
+        setAudioOutputId,
       }}
     >
       {children}

--- a/client/src/hooks/useAudioDevices.ts
+++ b/client/src/hooks/useAudioDevices.ts
@@ -5,7 +5,9 @@ export interface AudioDevice {
   label: string;
 }
 
-export function useAudioDevices() {
+export function useAudioDevices(
+  kind: 'audioinput' | 'audiooutput' = 'audioinput'
+) {
   const [devices, setDevices] = useState<AudioDevice[]>([]);
 
   const updateDevices = async () => {
@@ -13,8 +15,13 @@ export function useAudioDevices() {
       const list = await navigator.mediaDevices.enumerateDevices();
       setDevices(
         list
-          .filter((d) => d.kind === 'audioinput')
-          .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId}` }))
+          .filter((d) => d.kind === kind)
+          .map((d) => ({
+            deviceId: d.deviceId,
+            label:
+              d.label ||
+              `${kind === 'audioinput' ? 'Microphone' : 'Speaker'} ${d.deviceId}`,
+          }))
       );
     } catch (err) {
       console.warn('Failed to enumerate audio devices', err);

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -106,6 +106,7 @@
     "appearance": "Appearance",
     "language": "Language",
     "audioInput": "Microphone",
+    "audioOutput": "Speakers",
     "noAudioDevices": "No devices found",
     "darkMode": "Dark Mode",
     "lightMode": "Light Mode",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -118,6 +118,7 @@
     "appearance": "Внешний вид",
     "language": "Язык",
     "audioInput": "Микрофон",
+    "audioOutput": "Вывод звука",
     "noAudioDevices": "Устройства не найдены",
     "darkMode": "Темный режим",
     "lightMode": "Светлый режим",

--- a/client/src/pages/settings-section.tsx
+++ b/client/src/pages/settings-section.tsx
@@ -14,8 +14,16 @@ import { Label } from "@/components/ui/label";
 export default function SettingsSection() {
   const { user } = useAuth();
   const { t } = useTranslations();
-  const { language, setLanguage, audioInputId, setAudioInputId } = useSettings();
-  const { devices } = useAudioDevices();
+  const {
+    language,
+    setLanguage,
+    audioInputId,
+    setAudioInputId,
+    audioOutputId,
+    setAudioOutputId,
+  } = useSettings();
+  const { devices: inputDevices } = useAudioDevices('audioinput');
+  const { devices: outputDevices } = useAudioDevices('audiooutput');
 
   if (!user) return null;
 
@@ -45,10 +53,33 @@ export default function SettingsSection() {
             <SelectValue placeholder={t('settings.audioInput')} />
           </SelectTrigger>
           <SelectContent>
-            {devices.length === 0 ? (
+            {inputDevices.length === 0 ? (
               <SelectItem value="none">{t('settings.noAudioDevices')}</SelectItem>
             ) : (
-              devices.map((d) => (
+              inputDevices.map((d) => (
+                <SelectItem key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2 max-w-xs mt-4">
+        <Label htmlFor="audioOutput">{t('settings.audioOutput')}</Label>
+        <Select
+          value={audioOutputId ?? 'none'}
+          onValueChange={(val) => setAudioOutputId(val === 'none' ? null : val)}
+        >
+          <SelectTrigger id="audioOutput">
+            <SelectValue placeholder={t('settings.audioOutput')} />
+          </SelectTrigger>
+          <SelectContent>
+            {outputDevices.length === 0 ? (
+              <SelectItem value="none">{t('settings.noAudioDevices')}</SelectItem>
+            ) : (
+              outputDevices.map((d) => (
                 <SelectItem key={d.deviceId} value={d.deviceId}>
                   {d.label}
                 </SelectItem>


### PR DESCRIPTION
## Summary
- allow choosing between audio input and output devices
- store selected device ids in SettingsContext and in localStorage
- update settings UI to pick microphone and speaker
- apply selected devices to Jitsi calls

## Testing
- `pnpm run type-check`
