### PR TITLE
Add audio device controls to settings page

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -105,6 +105,8 @@
     "notifications": "Notifications",
     "appearance": "Appearance",
     "language": "Language",
+    "audioDevices": "Audio Devices",
+    "selectAudioDevices": "Select input and output devices",
     "audioInput": "Microphone",
     "audioOutput": "Speakers",
     "noAudioDevices": "No devices found",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -117,6 +117,8 @@
     "notifications": "Уведомления",
     "appearance": "Внешний вид",
     "language": "Язык",
+    "audioDevices": "Аудио устройства",
+    "selectAudioDevices": "Выбор устройств ввода и вывода",
     "audioInput": "Микрофон",
     "audioOutput": "Вывод звука",
     "noAudioDevices": "Устройства не найдены",

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslations } from '@/hooks/use-translations';
 import { useSettings } from '@/context/SettingsContext';
+import { useAudioDevices } from '@/hooks/useAudioDevices';
 import {
   Card,
   CardContent,
@@ -38,7 +39,18 @@ import { useAuth } from '@/hooks/use-auth';
 
 const SettingsPage: React.FC = () => {
   const { t } = useTranslations();
-  const { theme, setTheme, language, setLanguage } = useSettings();
+  const {
+    theme,
+    setTheme,
+    language,
+    setLanguage,
+    audioInputId,
+    setAudioInputId,
+    audioOutputId,
+    setAudioOutputId,
+  } = useSettings();
+  const { devices: inputDevices } = useAudioDevices('audioinput');
+  const { devices: outputDevices } = useAudioDevices('audiooutput');
   const { toast } = useToast();
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -292,6 +304,59 @@ const SettingsPage: React.FC = () => {
                     <SelectContent>
                       <SelectItem value="ru">Русский</SelectItem>
                       <SelectItem value="en">English</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('settings.audioDevices')}</CardTitle>
+                <CardDescription>{t('settings.selectAudioDevices')}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="audioInput">{t('settings.audioInput')}</Label>
+                  <Select
+                    value={audioInputId ?? 'none'}
+                    onValueChange={(val) => setAudioInputId(val === 'none' ? null : val)}
+                  >
+                    <SelectTrigger id="audioInput">
+                      <SelectValue placeholder={t('settings.audioInput')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {inputDevices.length === 0 ? (
+                        <SelectItem value="none">{t('settings.noAudioDevices')}</SelectItem>
+                      ) : (
+                        inputDevices.map((d) => (
+                          <SelectItem key={d.deviceId} value={d.deviceId}>
+                            {d.label}
+                          </SelectItem>
+                        ))
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="audioOutput">{t('settings.audioOutput')}</Label>
+                  <Select
+                    value={audioOutputId ?? 'none'}
+                    onValueChange={(val) => setAudioOutputId(val === 'none' ? null : val)}
+                  >
+                    <SelectTrigger id="audioOutput">
+                      <SelectValue placeholder={t('settings.audioOutput')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {outputDevices.length === 0 ? (
+                        <SelectItem value="none">{t('settings.noAudioDevices')}</SelectItem>
+                      ) : (
+                        outputDevices.map((d) => (
+                          <SelectItem key={d.deviceId} value={d.deviceId}>
+                            {d.label}
+                          </SelectItem>
+                        ))
+                      )}
                     </SelectContent>
                   </Select>
                 </div>


### PR DESCRIPTION
## Summary
- allow selecting audio input and output devices from Settings page
- update English and Russian locale files with text for audio device selection

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`
