### PR TITLE
Add group invites and fix message order

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -173,6 +173,7 @@
     "removeMember": "Remove member",
     "leaveGroup": "Leave group",
     "joinGroup": "Join group",
+    "inviteToGroup": "Invite to group",
     "groupCreated": "Group created",
     "groupDeleted": "Group deleted",
     "groupUpdated": "Group updated",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -185,6 +185,7 @@
     "removeMember": "Удалить участника",
     "leaveGroup": "Покинуть группу",
     "joinGroup": "Присоединиться к группе",
+    "inviteToGroup": "Пригласить в группу",
     "groupCreated": "Группа создана",
     "groupDeleted": "Группа удалена",
     "groupUpdated": "Группа обновлена",

--- a/client/src/pages/group-chat-section.tsx
+++ b/client/src/pages/group-chat-section.tsx
@@ -75,7 +75,11 @@ export default function GroupChatSection({ group }: Props) {
 
   if (!user) return null;
 
-  const plainMessages: MessageItem[] = messages.map((m) => ({
+  const ordered = [...messages].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+
+  const plainMessages: MessageItem[] = ordered.map((m) => ({
     id: m.id,
     senderId: m.senderId,
     content: m.content,

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useState, useCallback, useRef } from 'react';
 import { showError } from '@/lib/error-toast';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/use-auth';
 import { useChat } from '@/context/ChatContext';
 import { useWebSocket } from '@/hooks/useWebSocket';
@@ -23,6 +23,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
+  Users,
   Smile,
   X,
 } from 'lucide-react';
@@ -31,6 +32,21 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 import { MessageList } from '@/components/message-list';
@@ -62,6 +78,11 @@ export interface User {
   isonline: 0 | 1;
 }
 
+interface Group {
+  id: number;
+  name: string;
+}
+
 interface WsPacket<T = any> {
   type: string;
   payload: T;
@@ -80,6 +101,7 @@ export default function MessagesSection({ onStartCall }: Props) {
   const { user } = useAuth();
   const apiClient = createApiClient();
   const { t } = useTranslation();
+  const { toast } = useToast();
   const { connectionStatus, lastRawMessage, sendRaw } = useWebSocket();
 
   const { chatUser: selectedUser, setChatUser: setSelectedUser } = useChat();
@@ -94,6 +116,8 @@ export default function MessagesSection({ onStartCall }: Props) {
   const [contacts, setContacts] = useState<User[]>([]);
   const [contactSearch, setContactSearch] = useState('');
   const [showPicker, setShowPicker] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteGroupId, setInviteGroupId] = useState<number | null>(null);
 
   /* ─────────── contacts ─────────── */
   const {
@@ -104,6 +128,28 @@ export default function MessagesSection({ onStartCall }: Props) {
     queryKey: ['contacts'],
     queryFn: async () =>
       (await apiClient.request<User[]>('/contacts')) ?? [],
+  });
+
+  const { data: groups = [] } = useQuery<Group[]>({
+    queryKey: ['/api/groups'],
+    queryFn: async () => (await apiClient.request<Group[]>('/api/groups')) ?? [],
+  });
+
+  const inviteMutation = useMutation<void, Error, number>({
+    mutationFn: (groupId: number) =>
+      apiClient.request(`/api/groups/${groupId}/invite`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: selectedUser!.id }),
+      }),
+    onSuccess: () => {
+      toast({ title: t('groups.inviteToGroup'), description: 'Invite sent' });
+      setInviteOpen(false);
+      setInviteGroupId(null);
+    },
+    onError: (err: Error) => {
+      showError(err, 'Failed to invite');
+    },
   });
 
   useEffect(() => {
@@ -622,8 +668,25 @@ export default function MessagesSection({ onStartCall }: Props) {
                 >
                   <Video className="h-5 w-5" />
                 </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setInviteOpen(true)}
+                >
+                  <Users className="h-5 w-5" />
+                </Button>
               </div>
             )}
+          </div>
+        )}
+        {selectedUser && (
+          <div className="hidden md:flex items-center gap-2 p-3 border-b border-border bg-background">
+            <span className="flex-1 font-medium">
+              {selectedUser.firstName} {selectedUser.lastName}
+            </span>
+            <Button variant="outline" size="sm" onClick={() => setInviteOpen(true)}>
+              {t('groups.inviteToGroup')}
+            </Button>
           </div>
         )}
         {!selectedUser ? (
@@ -751,6 +814,36 @@ export default function MessagesSection({ onStartCall }: Props) {
           </>
         )}
       </section>
+      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('groups.inviteToGroup')}</DialogTitle>
+          </DialogHeader>
+          <Select
+            value={inviteGroupId ? inviteGroupId.toString() : ''}
+            onValueChange={(v) => setInviteGroupId(Number(v))}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder={t('groups.selectGroups', 'Select group')} />
+            </SelectTrigger>
+            <SelectContent>
+              {groups.map((g) => (
+                <SelectItem key={g.id} value={g.id.toString()}>{g.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                if (inviteGroupId) inviteMutation.mutate(inviteGroupId);
+              }}
+              disabled={inviteMutation.isPending || !inviteGroupId}
+            >
+              {inviteMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : t('common.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -320,7 +320,7 @@ router.get(
         WHERE ((sender_id = $1 AND receiver_id = $2)
            OR (sender_id = $2 AND receiver_id = $1))
           AND timestamp < $3
-        ORDER BY timestamp DESC
+        ORDER BY timestamp ASC
         LIMIT $4`,
         [userId, chatWith, before, limit]
       );
@@ -507,7 +507,7 @@ router.get('/groups/:groupId/messages', isAuthenticated, async (req: Request, re
          JOIN group_members gm ON gm.group_id = m.group_id AND gm.user_id = $1
          JOIN users u ON u.id = m.sender_id
         WHERE m.group_id = $2 AND m.timestamp < $3
-        ORDER BY m.timestamp DESC
+        ORDER BY m.timestamp ASC
         LIMIT $4`,
       [userId, groupId, before, limit]
     );

--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -110,4 +110,40 @@ router.get('/:id/users', isAuthenticated, async (req: Request, res: Response) =>
   }
 });
 
+// POST /api/groups/:id/invite - add a user to group
+router.post('/:id/invite', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const groupId = Number(req.params.id);
+    const { userId } = req.body as { userId: number };
+    if (!groupId || !userId) {
+      return res.status(400).json({ error: 'Invalid group or user' });
+    }
+    await db!.query(
+      'INSERT INTO group_members (group_id, user_id, is_admin) VALUES ($1, $2, 0) ON CONFLICT DO NOTHING',
+      [groupId, userId],
+    );
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('POST /groups/:id/invite error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// POST /api/groups/:id/join - current user joins group
+router.post('/:id/join', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const groupId = Number(req.params.id);
+    const userId = req.session.userId as number;
+    if (!groupId) return res.status(400).json({ error: 'Invalid group' });
+    await db!.query(
+      'INSERT INTO group_members (group_id, user_id, is_admin) VALUES ($1, $2, 0) ON CONFLICT DO NOTHING',
+      [groupId, userId],
+    );
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('POST /groups/:id/join error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- enable inviting or joining groups via new API routes
- sort chat messages chronologically
- allow inviting users to a group from the chat header
- add translations for new action

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`