### PR TITLE
Fix callLog export in util

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -3,3 +3,7 @@ export const log = (...args) => {
         console.log('[DEBUG]', ...args);
     }
 };
+
+export const callLog = (...args) => {
+    console.log('[call]', ...args);
+};


### PR DESCRIPTION
## Summary
- export `callLog` from util/logger.js to match the TypeScript source

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`