### PR TITLE
Fix P2P message fallback

### DIFF
--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -351,7 +351,7 @@ export default function MessagesSection({ onStartCall }: any) {
     appendMessage(user!.id, selectedUser!.id, tempMsg);
     setLocalMessages((prev) => [...prev, tempMsg]);
 
-    if (p2pStatus !== 'open') {
+    if (!viaP2P) {
       try {
         const saved = await apiClient.request<Message>('/messages', {
           method: 'POST',


### PR DESCRIPTION
## Summary
- ensure messages aren't sent to the server once a P2P connection is established

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_683e5c0167e4833090b3aa16d79216a7