### PR TITLE
Fix sidebar overlay transparency

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -85,7 +85,7 @@ export default function Sidebar({
       {/* Backdrop for mobile */}
       <div
         className={cn(
-          "fixed inset-0 bg-black/30 z-20 md:hidden transition-opacity duration-200",
+          "fixed inset-0 bg-black/80 z-20 md:hidden transition-opacity duration-200",
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none",
         )}
         onClick={() => setIsOpen(false)}


### PR DESCRIPTION
## Summary
- darken mobile sidebar backdrop to improve readability

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683e5dece5c48330974a8f8537ac4901