### PR TITLE
Add tasks catalog API and seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Set `VITE_STUN_SERVER` in `.env` to override the STUN server used by the client
 for peer connections. Use `VITE_STUN_SERVER=none` to disable STUN entirely when
 both peers are on the same local network.
 
+### Seeding task catalog
+
+Run the helper script to populate the `tasks_catalog` table with common
+helpdesk tasks:
+
+```bash
+pnpm exec node scripts/seed-tasks.cjs
+```
+
+The script inserts tasks only if they do not already exist.
+
 During development you can pass `-localp2p` to `pnpm run dev` to temporarily
 disable STUN/TURN and force local peer discovery:
 

--- a/client/src/api/tasks.ts
+++ b/client/src/api/tasks.ts
@@ -1,0 +1,9 @@
+import { createApiClient } from '@/lib/api-client';
+
+const api = createApiClient();
+
+export interface Task { id: number; name: string; category: string; }
+
+export async function getTasks(): Promise<Task[]> {
+  return (await api.request<Task[]>('/tasks')) ?? [];
+}

--- a/client/src/pages/request-modal.tsx
+++ b/client/src/pages/request-modal.tsx
@@ -34,6 +34,7 @@ import { insertRequestSchema } from "@shared/schema";
 import { z } from "zod";
 import { createApiClient } from "@/lib/api-client";
 import type { Request } from "./requests-section";
+import { getTasks } from "@/api/tasks";
 import { updateRequest } from "@/api/requests";
 
 export type Department = {
@@ -74,12 +75,12 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
 
   const [isError, setIsError] = useState<boolean>(false);
 
-  const taskOptions = [
-    { id: 1, name: "Не работает принтер" },
-    { id: 2, name: "Нет интернета" },
-    { id: 3, name: "Не работает проектор" },
-    { id: 4, name: "другое" },
-  ];
+  const { data: taskOptions = [], isLoading: tasksLoading, error: tasksError } =
+    useQuery({
+      queryKey: ["/api/tasks"],
+      queryFn: getTasks,
+      enabled: open,
+    });
 
   const form = useForm<RequestFormValues>({
     resolver: zodResolver(insertRequestSchema),
@@ -116,6 +117,19 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
       showError(departmentsError, 'Failed to load departments');
     }
   }, [departmentsError]);
+
+  useEffect(() => {
+    if (tasksError) {
+      setIsError(true);
+      showError(tasksError, 'Failed to load tasks');
+    }
+  }, [tasksError]);
+
+  useEffect(() => {
+    if (taskOptions.length && form.getValues().taskId === 0) {
+      form.setValue('taskId', taskOptions[0].id);
+    }
+  }, [taskOptions]);
 
   const saveRequest = useMutation({
     mutationFn: async (data: RequestFormValues) => {
@@ -210,11 +224,21 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {taskOptions.map((t) => (
-                        <SelectItem key={t.id} value={t.id.toString()}>
-                          {t.name}
-                        </SelectItem>
-                      ))}
+                      {tasksLoading ? (
+                        <div className="flex justify-center items-center h-10">
+                          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                        </div>
+                      ) : tasksError ? (
+                        <div className="text-center py-2 text-red-500">
+                          Error loading tasks. Please try again.
+                        </div>
+                      ) : (
+                        taskOptions.map((t) => (
+                          <SelectItem key={t.id} value={t.id.toString()}>
+                            {t.name}
+                          </SelectItem>
+                        ))
+                      )}
                     </SelectContent>
                   </Select>
                 </FormItem>

--- a/scripts/seed-tasks.cjs
+++ b/scripts/seed-tasks.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+require('dotenv').config();
+const { Client } = require('pg');
+
+const DB_URL = process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error('❌ DATABASE_URL env var not set');
+  process.exit(1);
+}
+
+const tasks = [
+  { id: 1, name: 'Не работает принтер', category: 'hardware' },
+  { id: 2, name: 'Нет интернета', category: 'network' },
+  { id: 3, name: 'Не работает проектор', category: 'hardware' },
+  { id: 4, name: 'Другое', category: 'other' },
+  { id: 5, name: 'Компьютер не включается', category: 'hardware' },
+  { id: 6, name: 'Нужна настройка ПО', category: 'software' },
+  { id: 7, name: 'Заменить картридж', category: 'hardware' },
+  { id: 8, name: 'Установить ПО', category: 'software' },
+];
+
+(async () => {
+  const client = new Client({ connectionString: DB_URL });
+  try {
+    await client.connect();
+    for (const t of tasks) {
+      const { rowCount } = await client.query('SELECT 1 FROM tasks_catalog WHERE id = $1', [t.id]);
+      if (rowCount === 0) {
+        await client.query('INSERT INTO tasks_catalog(id, name, category) VALUES($1,$2,$3)', [t.id, t.name, t.category]);
+        console.log(`✓ inserted task ${t.name}`);
+      } else {
+        console.log(`→ task ${t.id} already exists`);
+      }
+    }
+  } catch (err) {
+    console.error('❌ failed to seed tasks:', err);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+})();

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -17,6 +17,7 @@ import wikiRouter from './wiki';
 import requestsRouter from './requests';
 import adminRouter from './admin';
 import groupsRouter from './groups';
+import tasksRouter from './tasks';
 import notificationsRouter from './notifications';
 // import callLogsRouter from './call-logs';
 import {
@@ -33,6 +34,7 @@ const router = Router();
 router.use('/departments', isAuthenticated, departmentsRouter);
 router.use('/jobs', isAuthenticated, jobsRouter);
 router.use('/groups', isAuthenticated, groupsRouter);
+router.use('/tasks', isAuthenticated, tasksRouter);
 router.use('/requests', isAuthenticated, requestsRouter);
 router.use('/wiki', isAuthenticated, wikiRouter);
 router.use('/admin', isAuthenticated, adminRouter);

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { db } from '../db';
+
+const router = Router();
+
+// GET /api/tasks - list all tasks
+router.get('/', async (_req, res) => {
+  const { rows } = await db!.query('SELECT id, name, category FROM tasks_catalog ORDER BY id');
+  res.json(rows);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add tasks seeding script
- expose `/api/tasks` endpoint
- load tasks in request modal from API
- document seeding script

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_683e5eb04cd08330b452a385ddf527fa