### PR TITLE
Update AGENTS, add sidebar log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - **API client**: Prefer `createApiClient()` for all `fetch` calls.
 - **Push**: Register device tokens via `/api/notifications/register` and set
   `FCM_SERVER_KEY` in `.env` for push notifications.
+- **Sidebar**: Record all sidebar related work in `docs/sidebar-actions.md`.
 Feel free to add new things to the guidelines. This may be your notes on the project. See `docs/DEVELOPER_CHECKLIST_RU.md` for a high level TODO list in Russian.
 
 Note: Message bubbles use a lighter primary color for sent messages on the right and a darker gray for received messages on the left.

--- a/docs/sidebar-actions.md
+++ b/docs/sidebar-actions.md
@@ -1,0 +1,6 @@
+# Sidebar Actions Log
+
+This file tracks all changes and decisions related to the sidebar component.
+
+- [2024-06-03] Initial file created to log future sidebar work.
+


### PR DESCRIPTION
## Summary
- note that sidebar work is logged in `docs/sidebar-actions.md`
- create `docs/sidebar-actions.md` to keep track of sidebar changes

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_683e60bc61f88330ba6bdda9315d950d