### PR TITLE
Fix sidebar background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - **API client**: Prefer `createApiClient()` for all `fetch` calls.
 - **Push**: Register device tokens via `/api/notifications/register` and set
   `FCM_SERVER_KEY` in `.env` for push notifications.
-- **Sidebar**: Record all sidebar related work in `docs/sidebar-actions.md`.
+- **Sidebar**: Record all sidebar related work in `docs/sidebar-actions.md`. This file was created to track every sidebar update.
 Feel free to add new things to the guidelines. This may be your notes on the project. See `docs/DEVELOPER_CHECKLIST_RU.md` for a high level TODO list in Russian.
 
 Note: Message bubbles use a lighter primary color for sent messages on the right and a darker gray for received messages on the left.

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -94,7 +94,7 @@ export default function Sidebar({
       {/* Sidebar */}
       <aside
         className={cn(
-          "w-64 bg-primary-50 dark:bg-primary-900 border-r border-border text-primary-900 dark:text-primary-100 z-30 transition-transform duration-200 ease-in-out",
+          "w-64 bg-sidebar text-sidebar-foreground border-sidebar-border z-30 transition-transform duration-200 ease-in-out",
           "fixed left-0 top-0 bottom-0 md:relative md:translate-x-0",
           isOpen ? "translate-x-0" : "-translate-x-full",
         )}

--- a/docs/sidebar-actions.md
+++ b/docs/sidebar-actions.md
@@ -4,3 +4,5 @@ This file tracks all changes and decisions related to the sidebar component.
 
 - [2024-06-03] Initial file created to log future sidebar work.
 
+
+- [2025-06-03] Updated sidebar background to use bg-sidebar for proper visibility on small screens.


### PR DESCRIPTION
## Summary
- note that sidebar actions are tracked in docs/sidebar-actions.md
- use bg-sidebar classes for fixed sidebar background
- log this change in sidebar actions log

## Testing
- `pnpm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683e62680c408330a9e89691755dbdaa