### PR TITLE
Fix markdown breaks in wiki pages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^8.0.6",
+    "remark-breaks": "^5.0.0",
     "remark-gfm": "^3.0.1"
   },
   "devDependencies": {

--- a/client/src/components/wiki/markdown-preview.tsx
+++ b/client/src/components/wiki/markdown-preview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 interface MarkdownPreviewProps {
   content: string;
@@ -10,7 +11,9 @@ interface MarkdownPreviewProps {
 export function MarkdownPreview({ content, className }: MarkdownPreviewProps) {
   return (
     <div className={className}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/client/src/pages/wiki-article-page.tsx
+++ b/client/src/pages/wiki-article-page.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useRoute } from 'wouter';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { createApiClient } from '@/lib/api-client';
 import { useAuth } from '@/hooks/use-auth';
@@ -147,7 +148,9 @@ export default function WikiArticlePage() {
             )}
           </div>
           <div className="prose max-w-none">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{entry.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+              {entry.content}
+            </ReactMarkdown>
           </div>
         </>
       )}

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-hot-toast": "^2.5.2",
     "react-i18next": "^15.5.1",
     "react-markdown": "^8.0.6",
+    "remark-breaks": "^5.0.0",
     "react-resizable-panels": "^3.0.1",
     "recharts": "^2.15.3",
     "remark-gfm": "^3.0.1",

--- a/types/custom-modules.d.ts
+++ b/types/custom-modules.d.ts
@@ -2,3 +2,4 @@
 declare module '@vitejs/plugin-react';
 declare module 'vite-tsconfig-paths';
 declare module 'remark-gfm';
+declare module 'remark-breaks';


### PR DESCRIPTION
## Summary
- render single line breaks in wiki markdown using remark-breaks
- update type declarations for `remark-breaks`
- list `remark-breaks` dependency for root and client packages

## Testing
- `pnpm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_683e61f61340833095f68dc61868b8f4