### PR TITLE
Fix remark-breaks import resolution

### DIFF
--- a/client/src/components/wiki/markdown-preview.tsx
+++ b/client/src/components/wiki/markdown-preview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
+import remarkBreaks from '@/lib/remark-breaks';
 
 interface MarkdownPreviewProps {
   content: string;

--- a/client/src/lib/remark-breaks.ts
+++ b/client/src/lib/remark-breaks.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from 'unified'
+
+type Node = {
+  type: string
+  value?: string
+  children?: Node[]
+}
+
+function transform(node: Node): Node {
+  if (!node.children) return node
+
+  const result: Node[] = []
+  for (const child of node.children) {
+    if (child.type === 'text' && child.value && child.value.includes('\n')) {
+      const parts = child.value.split(/\r?\n/)
+      parts.forEach((part, index) => {
+        if (index > 0) result.push({ type: 'break' })
+        if (part) result.push({ type: 'text', value: part })
+      })
+    } else {
+      result.push(transform(child))
+    }
+  }
+  node.children = result
+  return node
+}
+
+const remarkBreaks: Plugin = () => (tree: Node) => {
+  transform(tree)
+}
+
+export default remarkBreaks

--- a/client/src/pages/wiki-article-page.tsx
+++ b/client/src/pages/wiki-article-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useRoute } from 'wouter';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
+import remarkBreaks from '@/lib/remark-breaks';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { createApiClient } from '@/lib/api-client';
 import { useAuth } from '@/hooks/use-auth';


### PR DESCRIPTION
## Summary
- add a local `remark-breaks` plugin implementation
- point wiki markdown components to the local plugin

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683e670092dc833084d2347b9e4015e2