### PR TITLE
Improve wiki readability on dark theme

### DIFF
--- a/client/src/pages/wiki-article-page.tsx
+++ b/client/src/pages/wiki-article-page.tsx
@@ -147,7 +147,7 @@ export default function WikiArticlePage() {
               </Button>
             )}
           </div>
-          <div className="prose max-w-none">
+          <div className="prose max-w-none dark:prose-invert">
             <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
               {entry.content}
             </ReactMarkdown>

--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -603,7 +603,7 @@ export default function WikiSection() {
                         )}
                       </CardHeader>
                       <CardContent>
-                        <div className="prose max-w-none">
+                        <div className="prose max-w-none dark:prose-invert">
                           <MarkdownPreview
                             content={getExcerpt(entry.content, 200)}
                           />


### PR DESCRIPTION
## Summary
- ensure wiki uses `prose-invert` when in dark mode

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing modules)*
- `pnpm install` *(fails: EHOSTUNREACH during package fetch)*

------
https://chatgpt.com/codex/tasks/task_e_683e69216b00833089fea6fa1ee90fa1