### PR TITLE
Enable Markdown rendering in chat messages

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from '@/lib/remark-breaks';
 import MessageStatusDot from './message-status-dot';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import UserHoverCard from '@/components/user-hover-card';
@@ -130,7 +133,11 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
               </div>
             </UserHoverCard>
           )}
-          <div>{m.content}</div>
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+              {m.content}
+            </ReactMarkdown>
+          </div>
           {m.file && (
             isImage(m.file) ? (
               <img


### PR DESCRIPTION
## Summary
- render chat messages using `react-markdown`
- add `remark-gfm` and custom `remark-breaks` plugins for message display

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' ...)*

------
https://chatgpt.com/codex/tasks/task_e_683e6a9ed0848330ab90da1bcfeaac43