### PR TITLE
Fix wiki markdown display

### DIFF
--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -11,3 +11,7 @@ export function getExcerpt(md: string, maxLength: number): string {
   const text = stripMarkdown(md);
   return text.length > maxLength ? text.slice(0, maxLength) + '...' : text;
 }
+
+export function getMarkdownSnippet(md: string, maxLength: number): string {
+  return md.length > maxLength ? md.slice(0, maxLength) + '...' : md;
+}

--- a/client/src/pages/wiki-section.tsx
+++ b/client/src/pages/wiki-section.tsx
@@ -65,7 +65,7 @@ import { useLocation } from "wouter";
 
 import { MarkdownPreview } from "../components/wiki/markdown-preview";
 import { MarkdownEditor } from "../components/wiki/markdown-editor";
-import { getExcerpt } from "../lib/markdown";
+import { getExcerpt, getMarkdownSnippet } from "../lib/markdown";
 
 // Схема формы для статей wiki
 const wikiEntryFormSchema = z.object({
@@ -605,7 +605,7 @@ export default function WikiSection() {
                       <CardContent>
                         <div className="prose max-w-none dark:prose-invert">
                           <MarkdownPreview
-                            content={getExcerpt(entry.content, 200)}
+                            content={getMarkdownSnippet(entry.content, 200)}
                           />
                         </div>
                         <div className="text-xs text-gray-500 mt-4">


### PR DESCRIPTION
## Summary
- show formatted snippets in the wiki list
- add a helper to truncate markdown content

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683e6cfc55048330b6649b4d3add4294