### PR TITLE
Fix emoji overlap

### DIFF
--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -130,7 +130,9 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
               </div>
             </UserHoverCard>
           )}
-          <div>{m.content}</div>
+          <div className="whitespace-pre-wrap leading-tight emoji-text">
+            {m.content}
+          </div>
           {m.file && (
             isImage(m.file) ? (
               <img

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -98,3 +98,10 @@
     --tw-ring-color: hsl(var(--sidebar-ring));
   }
 }
+
+/* Fix emoji overlap in messages */
+.emoji-text {
+  font-family: inherit, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+  line-height: 1.2;
+}
+


### PR DESCRIPTION
## Summary
- ensure emojis in messages don't overlap by adding a dedicated CSS class

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*


------
https://chatgpt.com/codex/tasks/task_e_683e6d35e2dc83308d3a5b106d6788cf