### PR TITLE
Fix emoji picker grid layout

### DIFF
--- a/client/src/components/emoji-picker.tsx
+++ b/client/src/components/emoji-picker.tsx
@@ -31,7 +31,7 @@ export default function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
         <button
           key={e}
           type="button"
-          className="text-xl hover:bg-muted rounded"
+          className="text-xl w-8 h-8 flex items-center justify-center hover:bg-muted rounded emoji-text"
           onClick={() => {
             onSelect(e);
             onClose?.();


### PR DESCRIPTION
## Summary
- prevent emoji buttons from overlapping by adding fixed dimensions and the `emoji-text` class

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9372bfc8330a0ff08d14afb200f