### PR TITLE
Fix session persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "wouter": "^3.7.0",
     "wrtc": "^0.4.7",
     "ws": "^8.18.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "connect-pg-simple": "^8.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,7 +5,9 @@ import express, {
   NextFunction,
   RequestHandler,
 } from 'express';
-import session from 'express-session';   
+import session from 'express-session';
+import connectPgSimple from 'connect-pg-simple';
+import { Pool } from 'pg';
 import cors from 'cors';
 import morgan from 'morgan';
 import pinoHttp from 'pino-http';
@@ -27,7 +29,13 @@ export function createApp(): AppInit {
   app.set('etag', false);
 
   /* ───────── SESSIONS ───────── */
-  const store = new session.MemoryStore();
+  const PgSession = connectPgSimple(session);
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const store = new PgSession({
+    pool,
+    tableName: 'session',
+    ttl: 7 * 24 * 60 * 60,
+  });
   const cookieDomain = process.env.COOKIE_DOMAIN;
   const sess = session({
     store,
@@ -39,15 +47,12 @@ export function createApp(): AppInit {
       secure: process.env.NODE_ENV === 'production',
       httpOnly: true,
       sameSite: 'lax',
-      maxAge: 60 * 60 * 1000,
+      maxAge: 7 * 24 * 60 * 60 * 1000,
       ...(cookieDomain ? { domain: cookieDomain } : {}),
     },
   });
-  if (typeof (store as any).prune === 'function') {
-    setInterval(() => (store as any).prune(), 60 * 60 * 1000);
-  }
   app.use(sess);
-  app.set('session-middleware', sess as RequestHandler); 
+  app.set('session-middleware', sess as RequestHandler);
 
   /* ───────── COMMON MIDDLEWARE ───────── */
   app.use(pinoHttp({ logger: logger as any, autoLogging: false }));


### PR DESCRIPTION
## Summary
- switch express-session store to connect-pg-simple
- keep sessions for seven days
- add connect-pg-simple dependency

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*

------
https://chatgpt.com/codex/tasks/task_e_683fa695f92c8330ac13caeb22ebcc1f