### PR TITLE
Fix requests to use subdivisions

### DIFF
--- a/client/src/pages/request-modal.tsx
+++ b/client/src/pages/request-modal.tsx
@@ -37,13 +37,13 @@ import type { Request } from "./requests-section";
 import { getTasks } from "@/api/tasks";
 import { updateRequest } from "@/api/requests";
 
-export type Department = {
+export type Subdivision = {
   id: number;
   name: string;
 };
 
 interface RequestFormValues {
-  receiverDepartmentId?: number;
+  receiverSubdivisionId?: number;
   taskId: number;
   cabinet: string;
   phone: string;
@@ -64,12 +64,16 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const apiClient = createApiClient();
-  const { data: departments = [], isLoading: isDepartmentsLoading, error: departmentsError } = useQuery<{ id: number; name: string }[]>({
+  const {
+    data: subdivisions = [],
+    isLoading: isSubdivisionsLoading,
+    error: subdivisionsError,
+  } = useQuery<{ id: number; name: string }[]>({
     queryKey: ["/api/departments"],
-      queryFn: async (): Promise<{ id:number; name:string }[]> => {
-        const depts = await apiClient.request<Department[]>('/api/departments');
-        return depts ?? [];    // никогда не null
-      },
+    queryFn: async (): Promise<{ id: number; name: string }[]> => {
+      const depts = await apiClient.request<Subdivision[]>("/api/departments");
+      return depts ?? [];
+    },
     enabled: open
   });
 
@@ -86,7 +90,7 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
     resolver: zodResolver(insertRequestSchema),
     defaultValues: request
       ? {
-          receiverDepartmentId: request.receiverDepartmentId,
+          receiverSubdivisionId: request.receiverSubdivisionId,
           taskId: request.taskId,
           cabinet: request.cabinet ?? '',
           phone: request.phone ?? '',
@@ -95,7 +99,7 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
           comment: request.comment ?? ''
         }
       : {
-          receiverDepartmentId: 0,
+          receiverSubdivisionId: 0,
           taskId: 0,
           cabinet: '',
           phone: '',
@@ -106,17 +110,17 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
   });
 
   useEffect(() => {
-    if (departments.length && form.getValues().receiverDepartmentId === undefined) {
-      form.reset({ ...form.getValues(), receiverDepartmentId: departments[0].id });
+    if (subdivisions.length && form.getValues().receiverSubdivisionId === undefined) {
+      form.reset({ ...form.getValues(), receiverSubdivisionId: subdivisions[0].id });
     }
-  }, [departments]);
+  }, [subdivisions]);
 
   useEffect(() => {
-    if (departmentsError) {
+    if (subdivisionsError) {
       setIsError(true);
-      showError(departmentsError, 'Failed to load departments');
+      showError(subdivisionsError, 'Failed to load departments');
     }
-  }, [departmentsError]);
+  }, [subdivisionsError]);
 
   useEffect(() => {
     if (tasksError) {
@@ -172,11 +176,11 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
           <form onSubmit={form.handleSubmit((data) => saveRequest.mutate(data))} className="space-y-4">
             <FormField
               control={form.control}
-              name="receiverDepartmentId"
+              name="receiverSubdivisionId"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Подразделение</FormLabel>
-                  {isDepartmentsLoading ? (
+                  {isSubdivisionsLoading ? (
                     <div className="flex justify-center items-center h-10">
                       <Loader2 className="h-8 w-8 animate-spin text-primary" />
                     </div>
@@ -196,7 +200,7 @@ export function RequestModal({ request, open, onOpenChange, onSuccess }: Props) 
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {departments.map((department: { id: number; name: string }) => (
+                      {subdivisions.map((department: { id: number; name: string }) => (
                         <SelectItem key={department.id} value={department.id.toString()}>
                           {department.name}
                         </SelectItem>

--- a/client/src/pages/requests-section.tsx
+++ b/client/src/pages/requests-section.tsx
@@ -19,7 +19,7 @@ export interface Request {
   id: number;
   senderId: number;
   status: 'новая' | 'в работе' | 'готово';
-  receiverDepartmentId: number;
+  receiverSubdivisionId: number;
   subdivision?: { id: number; name: string };
   taskId: number;
   task?: { id: number; name: string; category: string };

--- a/server/src/routes/departments.ts
+++ b/server/src/routes/departments.ts
@@ -3,9 +3,9 @@ import { db } from '../db';
 
 const router = Router();
 
-// GET /api/departments - list all departments
+// GET /api/departments - list all subdivisions
 router.get('/', async (_req, res) => {
-  const { rows } = await db!.query('SELECT id, name FROM departments ORDER BY name');
+  const { rows } = await db!.query('SELECT id, name FROM subdivisions ORDER BY name');
   res.json(rows);
 });
 

--- a/server/src/routes/requests.ts
+++ b/server/src/routes/requests.ts
@@ -11,7 +11,7 @@ router.get('/', async (req, res) => {
     `SELECT
        r.id,
        r.sender_id              AS "senderId",
-       r.receiver_department_id AS "receiverDepartmentId",
+       r.receiver_department_id AS "receiverSubdivisionId",
        json_build_object('id', d.id, 'name', d.name)            AS subdivision,
        r.task_id                AS "taskId",
        json_build_object('id', t.id, 'name', t.name, 'category', t.category) AS task,
@@ -28,11 +28,14 @@ router.get('/', async (req, res) => {
        r.status,
        r.created_at             AS "createdAt"
      FROM requests r
-       LEFT JOIN departments d ON r.receiver_department_id = d.id
+       LEFT JOIN subdivisions d ON r.receiver_department_id = d.id
        LEFT JOIN tasks_catalog t ON r.task_id = t.id
        LEFT JOIN users u ON r.who_accepted = u.id
     WHERE r.sender_id = $1
-       OR r.receiver_department_id IN (SELECT department_id FROM users WHERE id = $1)
+       OR r.receiver_department_id IN (
+            SELECT id FROM subdivisions
+            WHERE parent_id = (SELECT department_id FROM users WHERE id = $1)
+          )
     ORDER BY r.created_at DESC`,
     [userId]
   );
@@ -45,7 +48,7 @@ router.post('/', async (req, res) => {
   if (!parseResult.success) {
     return res.status(400).json({ error: 'Invalid request data' });
   }
-  const { receiverDepartmentId, taskId, cabinet, phone, isUrgent, deadline, comment } = parseResult.data;
+  const { receiverSubdivisionId, taskId, cabinet, phone, isUrgent, deadline, comment } = parseResult.data;
   const senderId = req.session.userId;
 
   // Normalize optional fields. Empty strings should be stored as NULL to avoid
@@ -60,7 +63,7 @@ router.post('/', async (req, res) => {
       'INSERT INTO requests(sender_id, receiver_department_id, task_id, cabinet, phone, is_urgent, deadline, comment) VALUES($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *',
       [
         senderId,
-        receiverDepartmentId,
+        receiverSubdivisionId,
         taskId,
         sanitizedCabinet,
         sanitizedPhone,

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -26,7 +26,7 @@ export interface Group {
 }
 
 export const insertRequestSchema = z.object({
-  receiverDepartmentId: z.number(),
+  receiverSubdivisionId: z.number(),
   taskId: z.number(),
   cabinet: z.string().optional(),
   phone: z


### PR DESCRIPTION
## Summary
- fetch subdivision list via `/api/departments`
- include subdivisions in request list queries
- update request creation and form to use `receiverSubdivisionId`

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68400490dfb483309bb67f1c6bf7b5f1