### PR TITLE
Fix admin user creation re-login issue

### DIFF
--- a/client/src/pages/admin-page.tsx
+++ b/client/src/pages/admin-page.tsx
@@ -175,7 +175,7 @@ export default function AdminPage() {
     e.preventDefault();
     try {
       setError(null);
-      await apiClient.request('/api/register', {
+      await apiClient.request('/api/admin/users', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newUser),

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -199,6 +199,29 @@ router.get('/users', isAuthenticated, async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/admin/users - create a new user without logging in
+router.post('/users', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const adminId = req.session.userId as number;
+    const { rows } = await db!.query<{ is_admin: boolean }>(
+      'SELECT is_admin FROM users WHERE id = $1',
+      [adminId],
+    );
+    if (!rows[0]?.is_admin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const newUser = await register(req.body);
+    res.status(201).json({ user: newUser });
+  } catch (err) {
+    logger.error('Admin user create error:', err);
+    if ((err as any).code === 'DUPLICATE') {
+      return res.status(409).json({ error: 'Username or email already exists' });
+    }
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
 // PATCH /api/admin/users/:id - update user fields (currently only isAdmin)
 router.patch('/users/:id', isAuthenticated, async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
## Summary
- add POST `/api/admin/users` endpoint that creates a user without logging in
- use new endpoint from admin page

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*
- `pnpm install` *(fails: Forbidden 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68400521ff7083309ff68943fa69658a