### PR TITLE
Add secret settings with Konami code

### DIFF
--- a/client/src/hooks/useKonami.ts
+++ b/client/src/hooks/useKonami.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+const KONAMI_SEQUENCE = [
+  'ArrowUp',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowRight',
+  'b',
+  'a',
+  'Enter',
+];
+
+export function useKonami() {
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    let index = 0;
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key;
+      if (key === KONAMI_SEQUENCE[index] || key.toLowerCase() === KONAMI_SEQUENCE[index]) {
+        index += 1;
+        if (index === KONAMI_SEQUENCE.length) {
+          setActive(true);
+          index = 0;
+        }
+      } else {
+        index = 0;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+  return active;
+}

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -103,6 +103,7 @@
     "account": "Account",
     "privacy": "Privacy",
     "notifications": "Notifications",
+    "secrets": "Secrets",
     "appearance": "Appearance",
     "language": "Language",
     "audioDevices": "Audio Devices",
@@ -130,7 +131,8 @@
     "privacySettings": "Privacy settings",
     "manageNotifications": "Manage notification preferences",
     "pushNotificationsDescription": "Receive push notifications on your device",
-    "desktopNotificationsDescription": "Receive notifications on your desktop"
+    "desktopNotificationsDescription": "Receive notifications on your desktop",
+    "secretMessage": "You've unlocked the secrets!"
   },
   "messages": {
     "noChat": "No chat",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -115,6 +115,7 @@
     "account": "Учетная запись",
     "privacy": "Конфиденциальность",
     "notifications": "Уведомления",
+    "secrets": "Секреты",
     "appearance": "Внешний вид",
     "language": "Язык",
     "audioDevices": "Аудио устройства",
@@ -142,7 +143,8 @@
     "privacySettings": "Настройки конфиденциальности",
     "manageNotifications": "Управление уведомлениями",
     "pushNotificationsDescription": "Получать push-уведомления на устройстве",
-    "desktopNotificationsDescription": "Получать уведомления на рабочем столе"
+    "desktopNotificationsDescription": "Получать уведомления на рабочем столе",
+    "secretMessage": "Вы открыли секреты!"
   },
   "messages": {
     "title": "Сообщения",

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -36,6 +36,7 @@ import { createApiClient } from '@/lib/api-client';
 import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon, ArrowLeft } from 'lucide-react';
 import { useLocation } from 'wouter';
 import { useAuth } from '@/hooks/use-auth';
+import { useKonami } from '@/hooks/useKonami';
 
 const SettingsPage: React.FC = () => {
   const { t } = useTranslations();
@@ -58,6 +59,7 @@ const SettingsPage: React.FC = () => {
   const [, setLocation] = useLocation();
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
+  const secretUnlocked = useKonami();
 
   const { data: jobs = [] } = useQuery<{ id: number; name: string }[]>({
     queryKey: ['/api/jobs'],
@@ -242,6 +244,12 @@ const SettingsPage: React.FC = () => {
             <Bell className="h-4 w-4" />
             <span>{t('settings.notifications')}</span>
           </TabsTrigger>
+          {secretUnlocked && (
+            <TabsTrigger value="secrets" className="flex items-center gap-2">
+              <Lock className="h-4 w-4" />
+              <span>{t('settings.secrets')}</span>
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="general">
@@ -458,6 +466,18 @@ const SettingsPage: React.FC = () => {
             </CardContent>
           </Card>
         </TabsContent>
+        {secretUnlocked && (
+          <TabsContent value="secrets">
+            <Card>
+              <CardHeader>
+                <CardTitle>{t('settings.secrets')}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p>{t('settings.secretMessage')}</p>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
       </Tabs>
 
       <div className="mt-8 flex justify-end">


### PR DESCRIPTION
## Summary
- add a `useKonami` hook to detect the Konami code
- show a hidden **Secrets** tab in settings when the code is entered
- provide localised strings for the new section

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684006363c0883308757643bc4503e38