### PR TITLE
Prevent self admin removal

### DIFF
--- a/client/src/pages/admin-page.tsx
+++ b/client/src/pages/admin-page.tsx
@@ -309,6 +309,7 @@ export default function AdminPage() {
                     <td className="px-3 py-2 text-center">
                       <Checkbox
                         checked={u.isAdmin}
+                        disabled={u.id === user?.id}
                         onCheckedChange={checked =>
                           setUserAdmin(u.id, checked === true)
                         }

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -217,6 +217,12 @@ router.patch('/users/:id', isAuthenticated, async (req: Request, res: Response) 
       return res.status(400).json({ error: 'Invalid request' });
     }
 
+    if (adminId === id && isAdmin === false) {
+      return res
+        .status(400)
+        .json({ error: "Can't remove your own admin rights" });
+    }
+
     await db!.query('UPDATE users SET is_admin = $1 WHERE id = $2', [isAdmin ? 1 : 0, id]);
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- disallow admins from removing their own privileges in backend
- disable the admin checkbox for the logged-in user

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*
- `pnpm exec jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684006577a488330ab38bd0efd95de21