### PR TITLE
Add explanation channels

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   WifiOffIcon,
   LucideIcon,
   BookOpenIcon,
+  InfoIcon,
   LogOutIcon,
   ShieldIcon,
   UsersIcon,
@@ -75,6 +76,7 @@ export default function Sidebar({
   const navItems: { id: SectionType; icon: LucideIcon; label: string; badge?: number }[] = [
     { id: "messages", icon: MessageSquareIcon, label: t("sidebar.nav.messages") },
     { id: "groups", icon: UsersIcon, label: t("sidebar.nav.groups") },
+    { id: "explanations", icon: InfoIcon, label: t("sidebar.nav.explanations") },
     { id: "requests", icon: ClipboardCheckIcon, label: t("sidebar.nav.requests"), badge: 2 },
     { id: "contacts", icon: ContactIcon, label: t("sidebar.nav.contacts") },
     { id: "wiki", icon: BookOpenIcon, label: t("sidebar.nav.wiki") || "Wiki" },

--- a/client/src/components/message-list.tsx
+++ b/client/src/components/message-list.tsx
@@ -131,7 +131,26 @@ export function MessageList({ messages, myId, groupMode = false, users = {} }: M
             </UserHoverCard>
           )}
           <div className="whitespace-pre-wrap leading-tight emoji-text">
-            {m.content}
+            {(() => {
+              const match = m.content.match(/\[([^\]]+)\]\((https?:[^)]+)\)$/);
+              if (match) {
+                return (
+                  <>
+                    {m.content.replace(match[0], '').trim()}
+                    <div className="mt-2">
+                      <a
+                        href={match[2]}
+                        target="_blank"
+                        className="px-2 py-1 bg-primary text-white rounded text-xs"
+                      >
+                        {match[1]}
+                      </a>
+                    </div>
+                  </>
+                );
+              }
+              return m.content;
+            })()}
           </div>
           {m.file && (
             isImage(m.file) ? (

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -325,6 +325,7 @@
       "messages": "Messages",
       "groups": "Groups",
       "announcements": "Announcements",
+      "explanations": "Explanations",
       "requests": "Requests",
       "users": "Users",
       "settings": "Settings"

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -70,6 +70,7 @@
       "messages": "Сообщения",
       "groups": "Группы",
       "announcements": "Объявления",
+      "explanations": "Объяснения",
       "contacts": "Контакты",
       "requests": "Заявки",
       "users": "Пользователи",

--- a/client/src/pages/explanations-section.tsx
+++ b/client/src/pages/explanations-section.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/use-auth';
+import { Button } from '@/components/ui/button';
+import { Loader2, Plus } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import GroupChatSection from '@/pages/group-chat-section';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { createApiClient } from '@/lib/api-client';
+import { queryClient } from '@/lib/queryClient';
+import { showError } from '@/lib/error-toast';
+import type { Group } from '@shared/schema';
+
+const createSchema = z.object({
+  name: z.string().min(1, 'Name required'),
+  description: z.string().optional(),
+});
+
+type CreateValues = z.infer<typeof createSchema>;
+
+export default function ExplanationsSection() {
+  const { user } = useAuth();
+  const { t } = useTranslation();
+  const apiClient = createApiClient();
+  const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const { data: groups = [], isLoading, error } = useQuery<Group[]>({
+    queryKey: ['/api/explanations'],
+    queryFn: async () => (await apiClient.request<Group[]>('/api/explanations')) ?? [],
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (data: CreateValues) =>
+      apiClient.request('/api/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, isExplanation: true }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/explanations'] });
+      setOpen(false);
+    },
+    onError: (err: Error) => showError(err, 'Failed to create'),
+  });
+
+  const form = useForm<CreateValues>({
+    resolver: zodResolver(createSchema),
+    defaultValues: { name: '', description: '' },
+  });
+
+  const onSubmit = (data: CreateValues) => createMutation.mutate(data);
+
+  if (selectedGroup) {
+    const readOnly = !user?.isAdmin && user?.id !== selectedGroup.creatorId;
+    return (
+      <div className="flex-1 overflow-auto">
+        <Button className="m-2" variant="ghost" onClick={() => setSelectedGroup(null)}>
+          {t('common.back', 'Back')}
+        </Button>
+        <GroupChatSection group={selectedGroup} readOnly={readOnly} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mb-6 flex justify-between items-center">
+        <h2 className="text-xl font-semibold">{t('sidebar.nav.explanations')}</h2>
+        {user?.isAdmin ? (
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button className="flex items-center">
+                <Plus className="mr-2 h-4 w-4" />
+                {t('groups.newGroup')}
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>{t('groups.newGroup')}</DialogTitle>
+                <DialogDescription>
+                  {t('groups.createGroup', 'Create group')}
+                </DialogDescription>
+              </DialogHeader>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Name</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Description</FormLabel>
+                        <FormControl>
+                          <Textarea className="min-h-[100px]" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <DialogFooter>
+                    <Button type="submit" disabled={createMutation.isPending}>
+                      {createMutation.isPending && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      )}
+                      {t('common.create', 'Create')}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </Form>
+            </DialogContent>
+          </Dialog>
+        ) : null}
+      </div>
+      {isLoading ? (
+        <div className="flex justify-center items-center h-40">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : error ? (
+        <div className="text-center py-10 text-red-500">{t('errors.somethingWentWrong')}</div>
+      ) : groups.length > 0 ? (
+        <ul className="space-y-2">
+          {groups.map((g) => (
+            <li key={g.id}>
+              <Button variant="ghost" className="w-full justify-start" onClick={() => setSelectedGroup(g)}>
+                {g.name}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-center text-gray-500">{t('announcements.noAnnouncements')}</p>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/group-chat-section.tsx
+++ b/client/src/pages/group-chat-section.tsx
@@ -15,6 +15,8 @@ import { showError } from '@/lib/error-toast';
 interface Group {
   id: number;
   name: string;
+  creatorId?: number;
+  isExplanation?: boolean;
 }
 
 interface GroupMessage extends MessageItem {
@@ -26,9 +28,10 @@ interface GroupMessage extends MessageItem {
 
 interface Props {
   group: Group;
+  readOnly?: boolean;
 }
 
-export default function GroupChatSection({ group }: Props) {
+export default function GroupChatSection({ group, readOnly }: Props) {
   const { user } = useAuth();
   const apiClient = createApiClient();
   const { t } = useTranslation();
@@ -39,6 +42,8 @@ export default function GroupChatSection({ group }: Props) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [showPicker, setShowPicker] = useState(false);
+
+  const isReadOnly = readOnly ?? (group.isExplanation && !user?.isAdmin && user?.id !== group.creatorId);
 
   const { data: messages = [], refetch } = useQuery<GroupMessage[]>({
     queryKey: ['group-messages', group.id],
@@ -119,6 +124,7 @@ export default function GroupChatSection({ group }: Props) {
       <div className="flex-1 overflow-y-auto p-4">
         <MessageList messages={plainMessages} myId={user.id} groupMode users={usersMap} />
       </div>
+      {!isReadOnly && (
       <form
         onSubmit={sendMessage}
         onDragOver={(e) => {
@@ -201,11 +207,12 @@ export default function GroupChatSection({ group }: Props) {
               e.target.value = '';
             }}
           />
-          <Button type="submit" disabled={!msgInput.trim() && files.length === 0}>
-            <Send className="h-4 w-4" />
-          </Button>
-        </div>
+        <Button type="submit" disabled={!msgInput.trim() && files.length === 0}>
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
       </form>
+      )}
     </div>
   );
 }

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -4,6 +4,7 @@ import Sidebar from "@/components/layout/sidebar";
 import MessagesSection from "@/pages/messages-section";
 import { GroupsSection } from "@/pages/groups-section";
 import AnnouncementsSection from "@/pages/announcements-section";
+import ExplanationsSection from "@/pages/explanations-section";
 import RequestsSection from "@/pages/requests-section";
 import ContactsSection from "@/pages/contacts-section";
 import SettingsSection from "@/pages/settings-section";
@@ -217,6 +218,8 @@ export default function HomePage() {
           )}
 
           {activeSection === "groups" && <GroupsSection />}
+
+          {activeSection === "explanations" && <ExplanationsSection />}
 
           {activeSection === "announcements" && <AnnouncementsSection />}
 

--- a/client/src/types/sections.ts
+++ b/client/src/types/sections.ts
@@ -1,5 +1,5 @@
-export type SectionType = 'messages' | 'groups' | 'announcements' | 'requests' | 'contacts' | 'settings' | 'wiki';
+export type SectionType = 'messages' | 'groups' | 'explanations' | 'announcements' | 'requests' | 'contacts' | 'settings' | 'wiki';
 
 export const isValidSection = (section: string): section is SectionType => {
-  return ['messages', 'groups', 'announcements', 'requests', 'contacts', 'settings', 'wiki'].includes(section);
+  return ['messages', 'groups', 'explanations', 'announcements', 'requests', 'contacts', 'settings', 'wiki'].includes(section);
 };

--- a/docs/sidebar-actions.md
+++ b/docs/sidebar-actions.md
@@ -6,3 +6,4 @@ This file tracks all changes and decisions related to the sidebar component.
 
 
 - [2025-06-03] Updated sidebar background to use bg-sidebar for proper visibility on small screens.
+- [2025-06-04] Added explanations menu item in sidebar.

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -18,6 +18,7 @@ import requestsRouter from './requests';
 import adminRouter from './admin';
 import groupsRouter from './groups';
 import announcementsRouter from './announcements';
+import explanationsRouter from './explanations';
 import tasksRouter from './tasks';
 import notificationsRouter from './notifications';
 // import callLogsRouter from './call-logs';
@@ -36,6 +37,7 @@ router.use('/departments', isAuthenticated, departmentsRouter);
 router.use('/jobs', isAuthenticated, jobsRouter);
 router.use('/groups', isAuthenticated, groupsRouter);
 router.use('/announcements', isAuthenticated, announcementsRouter);
+router.use('/explanations', isAuthenticated, explanationsRouter);
 router.use('/tasks', isAuthenticated, tasksRouter);
 router.use('/requests', isAuthenticated, requestsRouter);
 router.use('/wiki', isAuthenticated, wikiRouter);
@@ -550,6 +552,22 @@ router.post('/groups/:groupId/messages', isAuthenticated, async (req: Request, r
     const senderId = req.session.userId as number;
     const groupId = Number(req.params.groupId);
     if (!groupId) return res.status(400).json({ error: 'Invalid group' });
+
+    const info = await db!.query<{ creator_id: number; is_explanation: number }>(
+      'SELECT creator_id, is_explanation FROM groups WHERE id = $1',
+      [groupId]
+    );
+    const groupInfo = info.rows[0];
+    if (groupInfo?.is_explanation) {
+      const { rows } = await db!.query<{ is_admin: boolean }>(
+        'SELECT is_admin FROM users WHERE id = $1',
+        [senderId]
+      );
+      const isAdmin = rows[0]?.is_admin;
+      if (!isAdmin && groupInfo.creator_id !== senderId) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+    }
 
     const { content, file } = req.body as { content: string; file?: string };
     const insert = await db!.query(

--- a/server/src/routes/explanations.ts
+++ b/server/src/routes/explanations.ts
@@ -1,0 +1,30 @@
+import { Router, Request, Response } from 'express';
+import { db } from '../db';
+import { isAuthenticated } from '../middleware/auth';
+import { logger } from '../util/logger';
+
+const router = Router();
+
+// GET /api/explanations - list all explanation channels
+router.get('/', isAuthenticated, async (_req: Request, res: Response) => {
+  try {
+    const { rows } = await db!.query(
+      `SELECT g.id,
+              g.name,
+              g.description,
+              g.creator_id AS "creatorId",
+              d.name        AS "departmentName"
+         FROM groups g
+         JOIN users u ON u.id = g.creator_id
+         LEFT JOIN departments d ON u.department_id = d.id
+        WHERE g.is_explanation = 1
+        ORDER BY g.id DESC`
+    );
+    res.json(rows);
+  } catch (err) {
+    logger.error('GET /explanations error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -14,7 +14,8 @@ router.get('/', isAuthenticated, async (req: Request, res: Response) => {
               g.name,
               g.description,
               g.creator_id    AS "creatorId",
-              g.is_announcement AS "isAnnouncement"
+              g.is_announcement AS "isAnnouncement",
+              g.is_explanation AS "isExplanation"
          FROM groups g
          LEFT JOIN group_members gm ON gm.group_id = g.id AND gm.user_id = $1
         WHERE gm.user_id IS NOT NULL OR g.creator_id = $1
@@ -31,16 +32,17 @@ router.get('/', isAuthenticated, async (req: Request, res: Response) => {
 // POST /api/groups - create a new group
 router.post('/', isAuthenticated, async (req: Request, res: Response) => {
   try {
-    const { name, description, isAnnouncement } = req.body as {
+    const { name, description, isAnnouncement, isExplanation } = req.body as {
       name: string;
       description?: string;
       isAnnouncement?: boolean;
+      isExplanation?: boolean;
     };
     if (!name) return res.status(400).json({ error: 'Name required' });
     const creatorId = req.session.userId as number;
     const { rows } = await db!.query(
-      'INSERT INTO groups (name, description, creator_id, is_announcement) VALUES ($1, $2, $3, $4) RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement"',
-      [name, description ?? null, creatorId, isAnnouncement ? 1 : 0]
+      'INSERT INTO groups (name, description, creator_id, is_announcement, is_explanation) VALUES ($1, $2, $3, $4, $5) RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement", is_explanation AS "isExplanation"',
+      [name, description ?? null, creatorId, isAnnouncement ? 1 : 0, isExplanation ? 1 : 0]
     );
     const group = rows[0];
     await db!.query(
@@ -59,10 +61,11 @@ router.put('/:id', isAuthenticated, async (req: Request, res: Response) => {
   try {
     const id = Number(req.params.id);
     if (!id) return res.status(400).json({ error: 'Invalid id' });
-    const { name, description, isAnnouncement } = req.body as {
+    const { name, description, isAnnouncement, isExplanation } = req.body as {
       name?: string;
       description?: string;
       isAnnouncement?: boolean;
+      isExplanation?: boolean;
     };
     const fields: string[] = [];
     const values: any[] = [];
@@ -79,9 +82,13 @@ router.put('/:id', isAuthenticated, async (req: Request, res: Response) => {
       fields.push(`is_announcement = $${idx++}`);
       values.push(isAnnouncement ? 1 : 0);
     }
+    if (isExplanation !== undefined) {
+      fields.push(`is_explanation = $${idx++}`);
+      values.push(isExplanation ? 1 : 0);
+    }
     if (!fields.length) return res.status(400).json({ error: 'No fields' });
     values.push(id);
-    const query = `UPDATE groups SET ${fields.join(', ')} WHERE id = $$${idx} RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement"`;
+    const query = `UPDATE groups SET ${fields.join(', ')} WHERE id = $$${idx} RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement", is_explanation AS "isExplanation"`;
     const { rows } = await db!.query(query, values);
     res.json(rows[0]);
   } catch (err) {

--- a/server/uploads/85.plain
+++ b/server/uploads/85.plain
@@ -8246,8 +8246,11 @@ export { useToast, toast };
 
 --- File: C:\Users\DE81L\Downloads\CCNew\client\src\hooks\useAudioDevices.ts ---
 import { useEffect, useState } from 'react';
-
-export interface AudioDevice {
+  creatorId: integer("creator_id").references(() => users.id),
+  isAnnouncement: integer("is_announcement").default(0),
+  isExplanation: integer("is_explanation").default(0)
+});
+
   deviceId: string;
   label: string;
 }
@@ -8609,7 +8612,9 @@ export function useWiki() {
     mutationFn: async (id: number) => {
       const res = await fetch(`${API_BASE}/${id}`, {
         method: "DELETE",
-        credentials: "include",
+    isAnnouncement: (0, pg_core_1.integer)("is_announcement").default(0),
+    isExplanation: (0, pg_core_1.integer)("is_explanation").default(0)
+});
       });
       if (!res.ok) throw new Error(`DELETE ${API_BASE}/${id} → ${res.status}`);
     },

--- a/server/uploads/91.octet-stream
+++ b/server/uploads/91.octet-stream
@@ -152,7 +152,8 @@ CREATE TABLE public.groups (
     name text NOT NULL,
     description text,
     creator_id integer,
-    is_announcement integer DEFAULT 0
+    is_announcement integer DEFAULT 0,
+    is_explanation integer DEFAULT 0
 );
 
 

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -22,6 +22,8 @@ export interface Group {
   name: string;
   description?: string;
   isAnnouncement?: boolean;
+  creatorId?: number;
+  isExplanation?: boolean;
   members: User[];
 }
 

--- a/shared/src/types/entities.ts
+++ b/shared/src/types/entities.ts
@@ -15,4 +15,8 @@ export interface Group {
   description?: string;
   /** "Announcements‑only" channel, hides text‑input on the client */
   isAnnouncement?: boolean;
+  /** Creator ID for permission checks */
+  creatorId?: number;
+  /** Read-only explanation channel */
+  isExplanation?: boolean;
 }


### PR DESCRIPTION
## Summary
- introduce explanation channels as read‑only group chats
- show explanation channels in the sidebar
- add API route `/api/explanations`
- restrict posting in explanation channels to admins or channel creator
- render link buttons inside messages
- log sidebar update

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to compile due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684005b7af78833081875c364461ceee