### PR TITLE
Fix register import for admin route

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { db } from '../db';
 import { logger } from '../util/logger';
 import { isAuthenticated } from '../middleware/auth';
+import { register } from '../lib/api/auth';
 
 const router = Router();
 


### PR DESCRIPTION
## Summary
- add missing import for `register`

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684007b63a9483309dccaa682c7b3937