### PR TITLE
Fix SQL placeholder in groups update route

### DIFF
--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -88,7 +88,7 @@ router.put('/:id', isAuthenticated, async (req: Request, res: Response) => {
     }
     if (!fields.length) return res.status(400).json({ error: 'No fields' });
     values.push(id);
-    const query = `UPDATE groups SET ${fields.join(', ')} WHERE id = $$${idx} RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement", is_explanation AS "isExplanation"`;
+    const query = `UPDATE groups SET ${fields.join(', ')} WHERE id = $${idx} RETURNING id, name, description, creator_id AS "creatorId", is_announcement AS "isAnnouncement", is_explanation AS "isExplanation"`;
     const { rows } = await db!.query(query, values);
     res.json(rows[0]);
   } catch (err) {


### PR DESCRIPTION
## Summary
- correct SQL placeholder formatting in groups update endpoint

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing packages)*
- `pnpm install` *(fails: 403 Forbidden due to missing auth)*

------
https://chatgpt.com/codex/tasks/task_e_68400c2ebb3c8330a78d4b8407954315