### PR TITLE
Add secret Doom launcher

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -132,7 +132,8 @@
     "manageNotifications": "Manage notification preferences",
     "pushNotificationsDescription": "Receive push notifications on your device",
     "desktopNotificationsDescription": "Receive notifications on your desktop",
-    "secretMessage": "You've unlocked the secrets!"
+    "secretMessage": "You've unlocked the secrets!",
+    "playDoom": "Play DOOM"
   },
   "messages": {
     "noChat": "No chat",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -145,7 +145,8 @@
     "manageNotifications": "Управление уведомлениями",
     "pushNotificationsDescription": "Получать push-уведомления на устройстве",
     "desktopNotificationsDescription": "Получать уведомления на рабочем столе",
-    "secretMessage": "Вы открыли секреты!"
+    "secretMessage": "Вы открыли секреты!",
+    "playDoom": "Запустить DOOM"
   },
   "messages": {
     "title": "Сообщения",

--- a/client/src/lib/electron-types.ts
+++ b/client/src/lib/electron-types.ts
@@ -30,6 +30,7 @@ export interface ElectronAPI {
     maximize: () => Promise<void>;
     reload: () => Promise<void>;
     openDevTools: () => Promise<void>;
+    openDoom: () => Promise<void>;
   };
 
   // Операции файловой системы

--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -37,6 +37,7 @@ import { Bell, Moon, Sun, Globe, User, Lock, Settings as SettingsIcon, ArrowLeft
 import { useLocation } from 'wouter';
 import { useAuth } from '@/hooks/use-auth';
 import { useKonami } from '@/hooks/useKonami';
+import { useElectron } from '@/hooks/use-electron';
 
 const SettingsPage: React.FC = () => {
   const { t } = useTranslations();
@@ -60,6 +61,7 @@ const SettingsPage: React.FC = () => {
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
   const secretUnlocked = useKonami();
+  const { api, isElectron } = useElectron();
 
   const { data: jobs = [] } = useQuery<{ id: number; name: string }[]>({
     queryKey: ['/api/jobs'],
@@ -116,11 +118,15 @@ const SettingsPage: React.FC = () => {
 
     toast({
       title: t('settings.changesApplied'),
-      description: value 
+      description: value
         ? `${t('settings.' + type + 'Notifications')} ${t('common.enabled')}`
         : `${t('settings.' + type + 'Notifications')} ${t('common.disabled')}`,
       duration: 2000,
     });
+  };
+
+  const handlePlayDoom = () => {
+    api?.app?.openDoom?.();
   };
 
   const changePasswordSchema = z
@@ -474,6 +480,11 @@ const SettingsPage: React.FC = () => {
               </CardHeader>
               <CardContent>
                 <p>{t('settings.secretMessage')}</p>
+                {isElectron && (
+                  <Button className="mt-4" onClick={handlePlayDoom}>
+                    {t('settings.playDoom')}
+                  </Button>
+                )}
               </CardContent>
             </Card>
           </TabsContent>

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain, IpcMainEvent } from 'electron';
+import fs from 'fs';
 
 import path, { resolve } from 'node:path';
 import * as dotenv from 'dotenv';
@@ -50,6 +51,26 @@ ipcMain.handle('window-reload', () => {
 
 ipcMain.handle('open-devtools', () => {
   mainWindow?.webContents.openDevTools();
+});
+
+ipcMain.handle('open-doom', () => {
+  const doomPath = path.join(
+    __dirname,
+    '../../literal_copy_of_doom/doom-wasm/index.html'
+  );
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  if (fs.existsSync(doomPath)) {
+    win.loadFile(doomPath);
+  } else {
+    win.loadURL('data:text/html,DOOM files not found');
+  }
 });
 
 app.whenReady().then(createMainWindow);

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electron', {
     maximize: () => ipcRenderer.invoke('window-maximize'),
     reload: () => ipcRenderer.invoke('window-reload'),
     openDevTools: () => ipcRenderer.invoke('open-devtools'),
+    openDoom: () => ipcRenderer.invoke('open-doom'),
   },
   system: {
     getSystemInfo: () => ipcRenderer.invoke('get-system-info'),


### PR DESCRIPTION
## Summary
- expose `openDoom` from Electron preload and main process
- type it in `electron-types.ts`
- add a button in the secret settings tab to launch Doom
- include translations for the new button

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68404d5c160083309e5cf8957f9e517e