### PR TITLE
Add shift+enter send shortcut

### DIFF
--- a/client/src/pages/group-chat-section.tsx
+++ b/client/src/pages/group-chat-section.tsx
@@ -189,6 +189,12 @@ export default function GroupChatSection({ group, readOnly }: Props) {
             className="flex-1 resize-none max-h-24 overflow-y-auto"
             value={msgInput}
             onChange={handleInput}
+            onKeyDown={(e) => {
+              if (e.shiftKey && e.key === 'Enter') {
+                e.preventDefault();
+                void sendMessage(e as unknown as FormEvent);
+              }
+            }}
           />
           <input
             ref={fileInputRef}

--- a/client/src/pages/messages-section.tsx
+++ b/client/src/pages/messages-section.tsx
@@ -735,6 +735,12 @@ export default function MessagesSection({ onStartCall }: any) {
                   placeholder={t('messages.enterMessage')}
                   value={msgInput}
                   onChange={handleInput}
+                  onKeyDown={(e) => {
+                    if (e.shiftKey && e.key === 'Enter') {
+                      e.preventDefault();
+                      void sendMessage(e as unknown as FormEvent);
+                    }
+                  }}
                 />
                 <input
                   ref={fileInputRef}


### PR DESCRIPTION
## Summary
- enable sending messages with Shift+Enter in private and group chats

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68404fea6a4883308fd5046f7183b710