### PR TITLE
Rename "Объяснения" nav label

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -329,7 +329,7 @@
       "messages": "Messages",
       "groups": "Groups",
       "announcements": "Announcements",
-      "explanations": "Explanations",
+      "explanations": "Announcements",
       "requests": "Requests",
       "users": "Users",
       "settings": "Settings"

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -70,7 +70,7 @@
       "messages": "Сообщения",
       "groups": "Группы",
       "announcements": "Объявления",
-      "explanations": "Объяснения",
+      "explanations": "Объявления",
       "contacts": "Контакты",
       "requests": "Заявки",
       "users": "Пользователи",

--- a/docs/sidebar-actions.md
+++ b/docs/sidebar-actions.md
@@ -8,3 +8,4 @@ This file tracks all changes and decisions related to the sidebar component.
 - [2025-06-03] Updated sidebar background to use bg-sidebar for proper visibility on small screens.
 - [2025-06-04] Added explanations menu item in sidebar.
 - [2025-06-05] Renamed "Объяснения" menu item to "Объявления" in the Russian sidebar.
+- [2025-06-05] Renamed "Explanations" menu item to "Announcements" in the English sidebar.

--- a/docs/sidebar-actions.md
+++ b/docs/sidebar-actions.md
@@ -7,3 +7,4 @@ This file tracks all changes and decisions related to the sidebar component.
 
 - [2025-06-03] Updated sidebar background to use bg-sidebar for proper visibility on small screens.
 - [2025-06-04] Added explanations menu item in sidebar.
+- [2025-06-05] Renamed "Объяснения" menu item to "Объявления" in the Russian sidebar.


### PR DESCRIPTION
## Summary
- rename sidebar "объяснения" label to "объявления" in Russian locale
- document sidebar menu rename

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/remark-breaks: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68405241101883309398724c347381cc