### PR TITLE
Remove electron check for DOOM button

### DIFF
--- a/client/src/pages/settings-page.tsx
+++ b/client/src/pages/settings-page.tsx
@@ -61,7 +61,7 @@ const SettingsPage: React.FC = () => {
   const [pushNotifications, setPushNotifications] = React.useState(true);
   const [desktopNotifications, setDesktopNotifications] = React.useState(true);
   const secretUnlocked = useKonami();
-  const { api, isElectron } = useElectron();
+  const { api } = useElectron();
 
   const { data: jobs = [] } = useQuery<{ id: number; name: string }[]>({
     queryKey: ['/api/jobs'],
@@ -480,11 +480,9 @@ const SettingsPage: React.FC = () => {
               </CardHeader>
               <CardContent>
                 <p>{t('settings.secretMessage')}</p>
-                {isElectron && (
-                  <Button className="mt-4" onClick={handlePlayDoom}>
-                    {t('settings.playDoom')}
-                  </Button>
-                )}
+                <Button className="mt-4" onClick={handlePlayDoom}>
+                  {t('settings.playDoom')}
+                </Button>
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- drop `isElectron` check so that the Play DOOM button is visible in the web build

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz: Forbidden)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68405094417083308ccdcfb188f5ac07