### PR TITLE
Fix job/department migration script

### DIFF
--- a/scripts/fix-job-id.cjs
+++ b/scripts/fix-job-id.cjs
@@ -27,26 +27,59 @@ if (!DB_URL) {
       console.log('→ job_id column already exists');
     }
 
-    // Seed jobs table if empty
-    const jobCount = await client.query('SELECT COUNT(*) FROM jobs');
-    if (Number(jobCount.rows[0].count) === 0) {
-      await client.query(
-        `INSERT INTO jobs (name, department_id) VALUES
-         ('Recruiter', 1),
-         ('Software Engineer', 2)`
-      );
-      console.log('✓ Seeded default jobs');
-    } else {
-      console.log('→ jobs table already populated');
+    // Determine default department and job IDs
+    const { rows: dept } = await client.query(
+      'SELECT id FROM departments ORDER BY id LIMIT 1'
+    );
+    const defaultDeptId = dept[0]?.id;
+    if (!defaultDeptId) {
+      throw new Error('No departments found');
     }
 
-    // Update users.job_id based on job_title
+    let { rows: jobRows } = await client.query(
+      'SELECT id FROM jobs ORDER BY id LIMIT 1'
+    );
+    let defaultJobId = jobRows[0]?.id;
+
+    // Seed a placeholder job if table is empty
+    if (!defaultJobId) {
+      const ins = await client.query(
+        'INSERT INTO jobs(name, department_id) VALUES($1,$2) RETURNING id',
+        ['Default Job', defaultDeptId]
+      );
+      defaultJobId = ins.rows[0].id;
+      console.log('✓ Created placeholder job');
+    }
+
+    // Map job_title to job_id where possible
     await client.query(
       `UPDATE users SET job_id = j.id
        FROM jobs j
        WHERE users.job_title = j.name AND users.job_id IS NULL`
     );
-    console.log('✓ Updated users.job_id values');
+
+    // Fix invalid job_id values
+    await client.query(
+      `UPDATE users SET job_id = $1
+       WHERE job_id IS NULL OR job_id NOT IN (SELECT id FROM jobs)`,
+      [defaultJobId]
+    );
+
+    // Fix invalid department_id values
+    await client.query(
+      `UPDATE users SET department_id = $1
+       WHERE department_id IS NULL OR department_id NOT IN (SELECT id FROM departments)`,
+      [defaultDeptId]
+    );
+
+    // Ensure jobs have valid department_id
+    await client.query(
+      `UPDATE jobs SET department_id = $1
+       WHERE department_id IS NULL OR department_id NOT IN (SELECT id FROM departments)`,
+      [defaultDeptId]
+    );
+
+    console.log('✓ Normalized job and department references');
   } catch (err) {
     console.error('❌ Script failed:', err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- update migration script to avoid hardcoded jobs and departments
- normalize users and jobs to first available department/job when invalid

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684053dce3ec8330b1a3279cbccd6712