### PR TITLE
Refactor announcements flow

### DIFF
--- a/client/src/pages/announcements-section.tsx
+++ b/client/src/pages/announcements-section.tsx
@@ -113,12 +113,7 @@ export default function AnnouncementsSection() {
     return times[id % times.length];
   };
 
-  const openAnnouncement = async (a: Announcement) => {
-    try {
-      await apiClient.request(`/api/groups/${a.id}/join`, { method: 'POST' });
-    } catch (err) {
-      // ignore if already joined
-    }
+  const openAnnouncement = (a: Announcement) => {
     setSelectedGroup(a);
   };
 

--- a/client/src/pages/group-chat-section.tsx
+++ b/client/src/pages/group-chat-section.tsx
@@ -16,6 +16,7 @@ interface Group {
   id: number;
   name: string;
   creatorId?: number;
+  isAnnouncement?: boolean;
   isExplanation?: boolean;
 }
 
@@ -45,10 +46,13 @@ export default function GroupChatSection({ group, readOnly }: Props) {
 
   const isReadOnly = readOnly ?? (group.isExplanation && !user?.isAdmin && user?.id !== group.creatorId);
 
+  const messagesEndpoint = group.isAnnouncement
+    ? `/api/announcements/${group.id}/messages`
+    : `/api/groups/${group.id}/messages`;
   const { data: messages = [], refetch } = useQuery<GroupMessage[]>({
-    queryKey: ['group-messages', group.id],
+    queryKey: [group.isAnnouncement ? 'announcement-messages' : 'group-messages', group.id],
     queryFn: async () =>
-      (await apiClient.request<GroupMessage[]>(`/api/groups/${group.id}/messages`)) ?? [],
+      (await apiClient.request<GroupMessage[]>(messagesEndpoint)) ?? [],
   });
 
   useEffect(() => {

--- a/server/src/routes/announcements.ts
+++ b/server/src/routes/announcements.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { db } from '../db';
 import { isAuthenticated } from '../middleware/auth';
 import { logger } from '../util/logger';
+import { getFile, clearFile, findStoredFilePath } from '../store/messageStore';
 
 const router = Router();
 
@@ -23,6 +24,57 @@ router.get('/', isAuthenticated, async (_req: Request, res: Response) => {
     res.json(rows);
   } catch (err) {
     logger.error('GET /announcements error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// GET /api/announcements/:id/messages - list messages for an announcement
+router.get('/:id/messages', isAuthenticated, async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (!id) return res.status(400).json({ error: 'Invalid id' });
+
+    const { rows: g } = await db!.query<{ is_announcement: number }>(
+      'SELECT is_announcement FROM groups WHERE id = $1',
+      [id],
+    );
+    if (!g[0]?.is_announcement) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const limit = Math.min(Number(req.query.limit) || 50, 100);
+    const before = req.query.before ? new Date(req.query.before as string) : new Date();
+
+    const history = await db!.query(
+      `SELECT m.id,
+              m.sender_id   AS "senderId",
+              m.group_id    AS "groupId",
+              m.content,
+              m.timestamp,
+              m.status,
+              u.first_name  AS "firstName",
+              u.last_name   AS "lastName",
+              u.avatarurl  AS "avatarUrl"
+         FROM messages m
+         JOIN users u ON u.id = m.sender_id
+        WHERE m.group_id = $1 AND m.timestamp < $2
+        ORDER BY m.timestamp ASC
+        LIMIT $3`,
+      [id, before, limit]
+    );
+
+    const withFiles = history.rows.map((m) => {
+      let f = getFile(m.id);
+      if (!f) {
+        f = findStoredFilePath(m.id);
+      } else {
+        clearFile(m.id);
+      }
+      return { ...m, file: f ?? null };
+    });
+    res.json(withFiles);
+  } catch (err) {
+    logger.error('GET /announcements/:id/messages error:', err);
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -18,7 +18,8 @@ router.get('/', isAuthenticated, async (req: Request, res: Response) => {
               g.is_explanation AS "isExplanation"
          FROM groups g
          LEFT JOIN group_members gm ON gm.group_id = g.id AND gm.user_id = $1
-        WHERE gm.user_id IS NOT NULL OR g.creator_id = $1
+        WHERE (gm.user_id IS NOT NULL OR g.creator_id = $1)
+          AND g.is_announcement = 0
         ORDER BY g.name`,
       [userId]
     );


### PR DESCRIPTION
## Summary
- skip announcement groups when listing normal groups
- expose `/api/announcements/:id/messages`
- fetch announcement messages from the new endpoint
- stop joining announcement groups when opening

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68405629e4d08330827a06176a03fa9c