### PR TITLE
Fix DOOM modal

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -69,7 +69,7 @@ ipcMain.handle('open-doom', () => {
   if (fs.existsSync(doomPath)) {
     win.loadFile(doomPath);
   } else {
-    win.loadURL('data:text/html,DOOM files not found');
+    win.loadURL('https://js-dos.com/games/doom.exe.html');
   }
 });
 

--- a/literal_copy_of_doom/doom-wasm/index.html
+++ b/literal_copy_of_doom/doom-wasm/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>DOOM</title>
+<style>
+  html, body, #dos {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    background: black;
+  }
+</style>
+<script src="https://js-dos.com/6.22/current/js-dos.js"></script>
+</head>
+<body>
+<div id="dos"></div>
+<script>
+  Dos("#dos", { wdosboxUrl: "https://js-dos.com/6.22/current/wdosbox.js" })
+    .run("https://js-dos.com/games/doom.exe.jsdos");
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add wasm-based Doom page
- load hosted fallback if local Doom files are missing

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*

------
https://chatgpt.com/codex/tasks/task_e_68405a1b0c1c83308439cd1594db4caa