### PR TITLE
Implement WebSocket notification for new groups

### DIFF
--- a/client/src/pages/groups-section.tsx
+++ b/client/src/pages/groups-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
@@ -38,6 +38,7 @@ import { Loader2, Plus, Users, Eye, Pencil, Trash2 } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { useElectron } from "@/hooks/use-electron";
+import { useWebSocket } from "@/hooks/useWebSocket";
 import { queryClient } from "@/lib/queryClient";
 import { createApiClient } from "@/lib/api-client";
 import { showError } from "@/lib/error-toast";
@@ -171,6 +172,7 @@ function GroupCard({
 }
 export function GroupsSection() {
   const apiClient = createApiClient();
+  const { lastRawMessage } = useWebSocket();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [isCreateGroupDialogOpen, setIsCreateGroupDialogOpen] = useState(false);
@@ -196,6 +198,12 @@ export function GroupsSection() {
     queryFn: async (): Promise<User[]> =>
       (await apiClient.request<User[]>('/api/contacts')) ?? [],
   });
+
+  useEffect(() => {
+    if (lastRawMessage && (lastRawMessage as any).type === 'group-created') {
+      queryClient.invalidateQueries({ queryKey: ['/api/groups'] });
+    }
+  }, [lastRawMessage]);
   // Мутация создания группы
   const createGroupMutation = useMutation({
     mutationFn: (data: CreateGroupFormValues) =>

--- a/server/src/routes/groups.ts
+++ b/server/src/routes/groups.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { db } from '../db';
 import { isAuthenticated } from '../middleware/auth';
 import { logger } from '../util/logger';
+import { broadcastGroupCreated } from '../ws';
 
 const router = Router();
 
@@ -50,6 +51,7 @@ router.post('/', isAuthenticated, async (req: Request, res: Response) => {
       'INSERT INTO group_members (group_id, user_id, is_admin) VALUES ($1, $2, 1)',
       [group.id, creatorId]
     );
+    broadcastGroupCreated(group);
     res.status(201).json(group);
   } catch (err) {
     logger.error('POST /groups error:', err);

--- a/server/src/ws.ts
+++ b/server/src/ws.ts
@@ -136,6 +136,20 @@ export function broadcastStatus(
 }
 
 /**
+ * Broadcast notification that a group was created
+ */
+export function broadcastGroupCreated(group: any): void {
+  if (!wss) return;
+  const msg = JSON.stringify({
+    type: 'group-created',
+    payload: group,
+  });
+  wss.clients.forEach((c) => {
+    if (c.readyState === WebSocket.OPEN) c.send(msg);
+  });
+}
+
+/**
  * Серверная пересылка “chat” (если оба онлайн)
  */
 export function sendChatMessage(


### PR DESCRIPTION
## Summary
- broadcast `group-created` events from the server
- update group creation endpoint to send the broadcast
- listen for the event on the client and refresh the groups list

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz: Forbidden)*
- `pnpm exec jest` *(fails: Command "jest" not found)*
- `pnpm run type-check` *(fails: Cannot find module 'tslog')*

------
https://chatgpt.com/codex/tasks/task_e_68405adc7ff08330b06a4bcc7554b293