### PR TITLE
Add admin controls for user department and job

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -28,6 +28,7 @@ export interface UserWithoutPassword {
   lastName: string | null;
   jobId?: number | null;
   jobTitle?: string | null;
+  departmentId?: number | null;
   isAdmin?: number;
   isOnline: boolean | number;
   avatarUrl: string | null;

--- a/client/src/pages/admin-page.tsx
+++ b/client/src/pages/admin-page.tsx
@@ -36,6 +36,8 @@ export default function AdminPage() {
   const apiClient = createApiClient();
 
   const [users, setUsers] = useState<any[]>([]);
+  const [departments, setDepartments] = useState<{ id: number; name: string }[]>([]);
+  const [jobs, setJobs] = useState<{ id: number; name: string }[]>([]);
 
   const [newUser, setNewUser] = useState({
     username: '',
@@ -66,7 +68,28 @@ export default function AdminPage() {
         showError(err);
       }
     }
+
+    async function fetchDepartments() {
+      try {
+        const data = await apiClient.request<{ id: number; name: string }[]>('/api/departments');
+        setDepartments(data ?? []);
+      } catch (err) {
+        showError(err);
+      }
+    }
+
+    async function fetchJobs() {
+      try {
+        const data = await apiClient.request<{ id: number; name: string }[]>('/api/jobs');
+        setJobs(data ?? []);
+      } catch (err) {
+        showError(err);
+      }
+    }
+
     fetchUsers();
+    fetchDepartments();
+    fetchJobs();
   }, []);
 
   useEffect(() => {
@@ -196,14 +219,31 @@ export default function AdminPage() {
     }
   }
 
-  async function setUserAdmin(id: number, isAdmin: boolean) {
+  async function updateUser(id: number, data: Record<string, any>) {
     try {
       await apiClient.request(`/api/admin/users/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isAdmin }),
+        body: JSON.stringify(data),
       });
-      setUsers(prev => prev.map(u => (u.id === id ? { ...u, isAdmin } : u)));
+      setUsers(prev =>
+        prev.map(u =>
+          u.id === id
+            ? {
+                ...u,
+                ...data,
+                jobTitle:
+                  'jobId' in data
+                    ? jobs.find(j => j.id === data.jobId)?.name ?? null
+                    : u.jobTitle,
+                departmentName:
+                  'departmentId' in data
+                    ? departments.find(d => d.id === data.departmentId)?.name ?? null
+                    : u.departmentName,
+              }
+            : u,
+        ),
+      );
     } catch (err) {
       showError(err);
     }
@@ -297,6 +337,8 @@ export default function AdminPage() {
                   <th className="px-3 py-2 text-left text-sm font-semibold">ID</th>
                   <th className="px-3 py-2 text-left text-sm font-semibold">Username</th>
                   <th className="px-3 py-2 text-left text-sm font-semibold">Email</th>
+                  <th className="px-3 py-2 text-left text-sm font-semibold">{t('profile.department')}</th>
+                  <th className="px-3 py-2 text-left text-sm font-semibold">{t('profile.position')}</th>
                   <th className="px-3 py-2 text-center text-sm font-semibold">Admin</th>
                 </tr>
               </thead>
@@ -306,12 +348,56 @@ export default function AdminPage() {
                     <td className="px-3 py-2">{u.id}</td>
                     <td className="px-3 py-2">{u.username}</td>
                     <td className="px-3 py-2">{u.email}</td>
+                    <td className="px-3 py-2">
+                      <Select
+                        value={u.departmentId ? String(u.departmentId) : 'none'}
+                        onValueChange={val =>
+                          updateUser(u.id, {
+                            departmentId: val === 'none' ? null : Number(val),
+                          })
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="-" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">-</SelectItem>
+                          {departments.map(d => (
+                            <SelectItem key={d.id} value={String(d.id)}>
+                              {d.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Select
+                        value={u.jobId ? String(u.jobId) : 'none'}
+                        onValueChange={val =>
+                          updateUser(u.id, {
+                            jobId: val === 'none' ? null : Number(val),
+                          })
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="-" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">-</SelectItem>
+                          {jobs.map(j => (
+                            <SelectItem key={j.id} value={String(j.id)}>
+                              {j.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </td>
                     <td className="px-3 py-2 text-center">
                       <Checkbox
                         checked={u.isAdmin}
                         disabled={u.id === user?.id}
                         onCheckedChange={checked =>
-                          setUserAdmin(u.id, checked === true)
+                          updateUser(u.id, { isAdmin: checked === true })
                         }
                       />
                     </td>

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -191,7 +191,21 @@ router.get('/users', isAuthenticated, async (req: Request, res: Response) => {
     }
 
     const result = await db!.query(
-      `SELECT id, username, email, first_name AS "firstName", last_name AS "lastName", job_title AS "jobTitle", is_admin AS "isAdmin", isonline AS "isOnline" FROM users ORDER BY id`,
+      `SELECT
+         u.id,
+         u.username,
+         u.email,
+         u.first_name AS "firstName",
+         u.last_name  AS "lastName",
+         u.department_id AS "departmentId",
+         d.name        AS "departmentName",
+         u.job_id      AS "jobId",
+         u.job_title   AS "jobTitle",
+         u.is_admin    AS "isAdmin",
+         u.isonline    AS "isOnline"
+       FROM users u
+       LEFT JOIN departments d ON u.department_id = d.id
+       ORDER BY u.id`,
     );
     res.json({ users: result.rows });
   } catch (err) {
@@ -223,7 +237,7 @@ router.post('/users', isAuthenticated, async (req: Request, res: Response) => {
   }
 });
 
-// PATCH /api/admin/users/:id - update user fields (currently only isAdmin)
+// PATCH /api/admin/users/:id - update user fields (isAdmin, department, job)
 router.patch('/users/:id', isAuthenticated, async (req: Request, res: Response) => {
   try {
     const adminId = req.session.userId as number;
@@ -236,18 +250,54 @@ router.patch('/users/:id', isAuthenticated, async (req: Request, res: Response) 
     }
 
     const id = Number(req.params.id);
-    const { isAdmin } = req.body as { isAdmin?: boolean };
-    if (!id || typeof isAdmin !== 'boolean') {
-      return res.status(400).json({ error: 'Invalid request' });
+    const { isAdmin, departmentId, jobId } = req.body as {
+      isAdmin?: boolean;
+      departmentId?: number | null;
+      jobId?: number | null;
+    };
+    if (!id) {
+      return res.status(400).json({ error: 'Invalid id' });
     }
 
-    if (adminId === id && isAdmin === false) {
-      return res
-        .status(400)
-        .json({ error: "Can't remove your own admin rights" });
+    const updates: string[] = [];
+    const params: any[] = [];
+
+    if (typeof isAdmin === 'boolean') {
+      if (adminId === id && isAdmin === false) {
+        return res
+          .status(400)
+          .json({ error: "Can't remove your own admin rights" });
+      }
+      updates.push(`is_admin = $${params.length + 1}`);
+      params.push(isAdmin ? 1 : 0);
     }
 
-    await db!.query('UPDATE users SET is_admin = $1 WHERE id = $2', [isAdmin ? 1 : 0, id]);
+    if (departmentId !== undefined) {
+      updates.push(`department_id = $${params.length + 1}`);
+      params.push(departmentId);
+    }
+
+    if (jobId !== undefined) {
+      let title: string | null = null;
+      if (jobId) {
+        const { rows } = await db!.query<{ name: string }>(
+          'SELECT name FROM jobs WHERE id = $1',
+          [jobId]
+        );
+        title = rows[0]?.name ?? null;
+      }
+      updates.push(`job_id = $${params.length + 1}`);
+      params.push(jobId);
+      updates.push(`job_title = $${params.length + 1}`);
+      params.push(title);
+    }
+
+    if (!updates.length) {
+      return res.status(400).json({ error: 'No fields to update' });
+    }
+
+    params.push(id);
+    await db!.query(`UPDATE users SET ${updates.join(', ')} WHERE id = $${params.length}`, params);
     res.json({ success: true });
   } catch (err) {
     logger.error('Admin user update error:', err);

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -106,6 +106,7 @@ router.get('/user', isAuthenticated, async (req: Request, res: Response) => {
          email,
          first_name AS "firstName",
          last_name  AS "lastName",
+         department_id AS "departmentId",
          job_id     AS "jobId",
          job_title  AS "jobTitle",
          avatarurl  AS "avatarUrl",


### PR DESCRIPTION
## Summary
- expose departmentId on `/api/user`
- include department and job info in admin user list
- allow admins to update user department/job via `/api/admin/users/:id`
- fetch departments/jobs in admin panel and show editable selects
- store department info in auth context

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68406556940083309a40ababf064d5c1