### PR TITLE
Enable raw HTML in wiki markdown

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^8.0.6",
     "remark-breaks": "^5.0.0",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^3.0.1",
+    "rehype-raw": "^6.1.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.4.1",

--- a/client/src/components/wiki/markdown-preview.tsx
+++ b/client/src/components/wiki/markdown-preview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from '@/lib/remark-breaks';
+import rehypeRaw from 'rehype-raw';
 
 interface MarkdownPreviewProps {
   content: string;
@@ -11,7 +12,10 @@ interface MarkdownPreviewProps {
 export function MarkdownPreview({ content, className }: MarkdownPreviewProps) {
   return (
     <div className={className}>
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={[rehypeRaw]}
+      >
         {content}
       </ReactMarkdown>
     </div>

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-resizable-panels": "^3.0.1",
     "recharts": "^2.15.3",
     "remark-gfm": "^3.0.1",
+    "rehype-raw": "^6.1.1",
     "rimraf": "^6.0.1",
     "simple-peer": "^9.11.1",
     "sonner": "^2.0.3",


### PR DESCRIPTION
## Summary
- support HTML rendering in markdown preview
- add `rehype-raw` dependency

## Testing
- `pnpm run type-check` *(fails: Cannot find module 'tslog' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684266ff41888330bbeae0036901150e