### PR TITLE
Update production start options

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -25,6 +25,7 @@ pnpm prune --prod
 
 ```bash
 ./scripts/run-production.sh
+# Скрипт запускает Node.js с флагом `--es-module-specifier-resolution=node` для корректной загрузки ESM модулей
 ```
 
 Перед запуском при необходимости переопределите `DATABASE_URL`, `VITE_API_URL`

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -10,4 +10,5 @@
 
 - [2025-06-21] Добавлен скрипт `run-production.sh` и примеры unit-файлов systemd в каталоге scripts.
 - [2025-06-22] Улучшен скрипт `run-production.sh`: установка зависимостей без `--prod`, одобрение build-скриптов и `pnpm prune` после сборки.
+- [2025-06-23] Добавлен флаг `--es-module-specifier-resolution=node` в `run-production.sh` и unit-файле `cc2-node.service`.
 

--- a/scripts/run-production.sh
+++ b/scripts/run-production.sh
@@ -31,7 +31,8 @@ pnpm prune --prod
 # Запускаем сервисы
 python3 python_ws_server.py --host 0.0.0.0 --port "$PYWS_PORT" &
 PYWS_PID=$!
-node dist/server/index.js &
+DIR=$(cd -- "$(dirname "$0")"/.. && pwd)
+node --es-module-specifier-resolution=node "$DIR/dist/server/main.js" &
 NODE_PID=$!
 
 echo "Запущены Node.js (PID $NODE_PID, порт $PORT) и Python WS (PID $PYWS_PID, порт $PYWS_PORT)"

--- a/scripts/systemd/cc2-node.service
+++ b/scripts/systemd/cc2-node.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 WorkingDirectory=/opt/CorporateCommunicator2
-ExecStart=/usr/bin/node /opt/CorporateCommunicator2/dist/server/index.js
+ExecStart=/usr/bin/node --es-module-specifier-resolution=node /opt/CorporateCommunicator2/dist/server/main.js
 Environment=NODE_ENV=production
 Environment=PORT=4000
 Environment=NO_NODE_WS=1


### PR DESCRIPTION
## Summary
- use `--es-module-specifier-resolution=node` when starting the server in `run-production.sh`
- adjust systemd unit accordingly
- mention the new flag in production docs
- log the update in `server-actions.md`

## Testing
- `pnpm exec jest` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685063e1f8288330adc39b83d5969e64