### PR TITLE
Decouple electron from server dev tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ pnpm install
 pnpm run dev
 ```
 
+Для запуска только серверных служб (Node и Python WS) без клиента используйте:
+
+```bash
+pnpm run dev:server-pyws
+```
+
 ## Сборка
 
 ```bash

--- a/docs/electron-actions.md
+++ b/docs/electron-actions.md
@@ -9,3 +9,5 @@ This file tracks all changes related to the Electron wrapper and packaging.
 - [2025-06-18] Обновлена конфигурация tsconfig в electron для корректной работы путей.
 - [2025-06-19] Указан baseUrl в tsconfig для корректной работы путей.
 - [2025-06-20] Исправлен импорт типов в хуке `useLogin.ts`, теперь используются относительные пути.
+
+- [2025-06-24] Electron исключён из зависимостей корневого пакета и не запускается в `pnpm run dev`.

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -12,3 +12,5 @@
 - [2025-06-22] Улучшен скрипт `run-production.sh`: установка зависимостей без `--prod`, одобрение build-скриптов и `pnpm prune` после сборки.
 - [2025-06-23] Добавлен флаг `--es-module-specifier-resolution=node` в `run-production.sh` и unit-файле `cc2-node.service`.
 
+
+- [2025-06-24] Добавлен скрипт `run-dev-server-pyws.sh` для локального запуска Node и Python без клиента.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev:debug": "cross-env NODE_OPTIONS=\"--inspect=9229\" pnpm run dev",
     "dev:electron": "pnpm --filter ccnew-electron run dev",
     "dev:server": "pnpm --filter server run dev",
+    "dev:server-pyws": "./scripts/run-dev-server-pyws.sh",
     "log-check": "node scripts/analyse-log.js",
-    "postinstall": "node ./node_modules/electron/install.js",
     "ts-report": "pnpm run type-check --pretty false --noEmit > ts-report.log",
     "build:shared": "tsc -p shared/tsconfig.json",
     "build:electron": "pnpm --filter ccnew-electron run build",
@@ -72,7 +72,6 @@
     "debug": "latest",
     "dotenv": "^16.5.0",
     "drizzle-orm": "latest",
-    "electron": "36.2.0",
     "embla-carousel-react": "^8.6.0",
     "express-session": "^1.18.1",
     "gel": "^2.1.0",
@@ -119,6 +118,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
     "@types/bcrypt": "^5.0.2",
+    "electron": "36.2.0",
     "@types/cors": "^2.8.18",
     "@types/debug": "latest",
     "@types/express": "^4.17.17",
@@ -151,7 +151,7 @@
   "type": "module",
   "workspaces": [
     "client",
-    "packages/ccnew-electron",
+    "electron",
     "server",
     "shared"
   ],

--- a/scripts/run-dev-server-pyws.sh
+++ b/scripts/run-dev-server-pyws.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─────────── директории ───────────
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PY_ENV="${ROOT_DIR}/.venv"
+
+# ─────────── Python: venv + deps ──────────
+if [[ ! -d "$PY_ENV" ]]; then
+  echo "[pyws] creating venv @ $PY_ENV"
+  python3.12 -m venv "$PY_ENV"
+fi
+source "$PY_ENV/bin/activate"
+
+pip install --upgrade pip
+pip install -r "$ROOT_DIR/requirements.txt"
+
+# ─────────── Запуск сервисов ──────────
+pnpm --filter server run dev &
+NODE_PID=$!
+
+python "$ROOT_DIR/python_ws_server.py" &
+PYWS_PID=$!
+
+trap "kill $NODE_PID $PYWS_PID" EXIT
+wait

--- a/scripts/run-dev.cjs
+++ b/scripts/run-dev.cjs
@@ -23,12 +23,11 @@ if (pyws) {
   }
 }
 
-const names = ['server', 'client', 'electron'];
-const colors = ['green', 'blue', 'magenta'];
+const names = ['server', 'client'];
+const colors = ['green', 'blue'];
 const commands = [
   'pnpm run dev:server',
-  'pnpm run dev:client',
-  'pnpm run dev:electron'
+  'pnpm run dev:client'
 ];
 
 if (pyws) {


### PR DESCRIPTION
## Summary
- move electron to devDependencies and drop postinstall
- tweak workspace path to electron
- remove electron from default dev script
- add backend-only dev mode and document it
- record actions in docs logs

## Testing
- `pnpm exec jest` *(fails: cannot download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68506f4530e08330a72a6f2fdf95a2de