### PR TITLE
Enable skipLibCheck in tsconfig

### DIFF
--- a/docs/agents-actions.md
+++ b/docs/agents-actions.md
@@ -13,3 +13,4 @@
 - [2025-06-23] Обновлён скрипт run-production.sh: сборка только shared и server, добавлен requirements.txt.
 - [2025-06-24] Скрипт run-production.sh допускает отсутствие сборки Node.
 - [2025-06-26] Добавлены скрипты dev-all.sh и run-pyws.sh, обновлены tsconfig и package.json для локальной разработки.
+- [2025-06-27] Включён skipLibCheck в tsconfig проектов server и shared.

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -20,3 +20,4 @@
 - [2025-06-25] Исправлены типы роутеров Express для успешной сборки.
 - [2025-06-17] Скрипт run-production.sh завершает зависший python_ws_server перед запуском.
 - [2025-06-26] Упрощены tsconfig проектов shared и server для commonjs-сборки.
+- [2025-06-27] В tsconfig проектов server и shared включён skipLibCheck для устранения ошибок библиотек.

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,8 +5,15 @@
     "rootDir": "src",
     "outDir": "../dist/server",
     "composite": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
-  "include": ["src"],
-  "references": [{ "path": "../shared" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ]
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -6,7 +6,10 @@
     "outDir": "../dist/shared",
     "declaration": true,
     "composite": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
## Summary
- enable `skipLibCheck` in server and shared builds
- document the change in server- and agent-action logs

## Testing
- `tsc -p shared/tsconfig.json` *(fails: Cannot find module 'tslog')*
- `tsc -p server/tsconfig.json` *(fails: Cannot write tsbuildinfo)*

------
https://chatgpt.com/codex/tasks/task_e_6850a4ea236483309ec74a4542d373ea