### PR TITLE
Fix TS build conflict

### DIFF
--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -21,3 +21,4 @@
 - [2025-06-17] Скрипт run-production.sh завершает зависший python_ws_server перед запуском.
 - [2025-06-26] Упрощены tsconfig проектов shared и server для commonjs-сборки.
 - [2025-06-27] В tsconfig проектов server и shared включён skipLibCheck для устранения ошибок библиотек.
+- [2025-06-28] Указан путь tsBuildInfoFile для проекта server, чтобы избежать конфликтов сборки.

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "../dist/server",
+    "tsBuildInfoFile": "../dist/server/tsconfig.tsbuildinfo",
     "composite": true,
     "esModuleInterop": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- specify `tsBuildInfoFile` for server build
- log the change in server actions documentation

## Testing
- `pnpm run build:prod` *(fails: Error: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6850a8924a0c8330894b5adc70d00ceb