### PR TITLE
Fix path aliases

### DIFF
--- a/docs/agents-actions.md
+++ b/docs/agents-actions.md
@@ -14,3 +14,4 @@
 - [2025-06-24] Скрипт run-production.sh допускает отсутствие сборки Node.
 - [2025-06-26] Добавлены скрипты dev-all.sh и run-pyws.sh, обновлены tsconfig и package.json для локальной разработки.
 - [2025-06-27] Включён skipLibCheck в tsconfig проектов server и shared.
+- [2025-07-04] Скрипт run-production.sh теперь подключает tsconfig-paths/register для корректной работы алиасов.

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -28,3 +28,4 @@
 
 - [2025-07-02] Заменено "type" в server/package.json на "module" для корректной сборки.
 - [2025-07-03] Возврат к CommonJS: tsconfig серверных проектов и package.json теперь используют CommonJS.
+- [2025-07-04] run-production.sh запускает Node с параметром -r tsconfig-paths/register.

--- a/scripts/run-production.sh
+++ b/scripts/run-production.sh
@@ -32,7 +32,8 @@ pkill -f python_ws_server.py 2>/dev/null || true
 PYWS_PID=$!
 
 if [[ -f "$ROOT_DIR/dist/server/index.js" ]]; then
-  node "$ROOT_DIR/dist/server/index.js" &
+  # подключаем резолвер путей tsconfig, иначе алиасы не работают
+  node -r tsconfig-paths/register "$ROOT_DIR/dist/server/index.js" &
   NODE_PID=$!
   echo "[OK] pyws($PYWS_PID) + node($NODE_PID) подняты"
 else


### PR DESCRIPTION
## Summary
- resolve tsconfig alias in production script
- document actions

## Testing
- `pnpm run start:prod` *(fails: fetch to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850b86b6fd48330a270d727a22f93fc