### PR TITLE
Fix tsconfig-paths in production script

### DIFF
--- a/docs/agents-actions.md
+++ b/docs/agents-actions.md
@@ -15,3 +15,4 @@
 - [2025-06-26] Добавлены скрипты dev-all.sh и run-pyws.sh, обновлены tsconfig и package.json для локальной разработки.
 - [2025-06-27] Включён skipLibCheck в tsconfig проектов server и shared.
 - [2025-07-04] Скрипт run-production.sh теперь подключает tsconfig-paths/register для корректной работы алиасов.
+- [2025-07-05] Уточнена конфигурация tsconfig-paths: export TS_NODE_PROJECT в run-production.sh.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -27,6 +27,8 @@ pnpm run build:prod
 pnpm run start:prod
 ```
 Скрипт автоматически создаёт виртуальное окружение Python и запускает Node.js.
+Он также экспортирует переменную `TS_NODE_PROJECT`, чтобы `tsconfig-paths` смог
+корректно найти конфигурацию `server/tsconfig.json`.
 
 Перед запуском при необходимости переопределите `DATABASE_URL`, `VITE_API_URL`
 и `VITE_WS_URL`. Скрипт по умолчанию использует адрес `91.197.96.9`.

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -29,3 +29,4 @@
 - [2025-07-02] Заменено "type" в server/package.json на "module" для корректной сборки.
 - [2025-07-03] Возврат к CommonJS: tsconfig серверных проектов и package.json теперь используют CommonJS.
 - [2025-07-04] run-production.sh запускает Node с параметром -r tsconfig-paths/register.
+- [2025-07-05] run-production.sh экспортирует переменную TS_NODE_PROJECT для корректного поиска tsconfig.

--- a/scripts/run-production.sh
+++ b/scripts/run-production.sh
@@ -33,6 +33,7 @@ PYWS_PID=$!
 
 if [[ -f "$ROOT_DIR/dist/server/index.js" ]]; then
   # подключаем резолвер путей tsconfig, иначе алиасы не работают
+  export TS_NODE_PROJECT="$ROOT_DIR/server/tsconfig.json"
   node -r tsconfig-paths/register "$ROOT_DIR/dist/server/index.js" &
   NODE_PID=$!
   echo "[OK] pyws($PYWS_PID) + node($NODE_PID) подняты"


### PR DESCRIPTION
## Summary
- export `TS_NODE_PROJECT` in `run-production.sh` so that `tsconfig-paths` can locate alias configuration
- document production script update in deployment guide and action logs

## Testing
- `pnpm exec jest` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850ba581db4833081f847dcff75780a