### PR TITLE
Fix server path alias

### DIFF
--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -30,3 +30,4 @@
 - [2025-07-03] Возврат к CommonJS: tsconfig серверных проектов и package.json теперь используют CommonJS.
 - [2025-07-04] run-production.sh запускает Node с параметром -r tsconfig-paths/register.
 - [2025-07-05] run-production.sh экспортирует переменную TS_NODE_PROJECT для корректного поиска tsconfig.
+- [2025-07-06] Исправлены алиасы в server/tsconfig.json: baseUrl '../', paths указывают на dist/shared для корректного запуска.

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,6 +6,11 @@
     "moduleResolution": "node",
     "rootDir": "src",
     "outDir": "../dist/server",
+    "baseUrl": "../",
+    "paths": {
+      "@shared/*": ["dist/shared/*"],
+      "@shared/types/*": ["dist/shared/types/*"]
+    },
     "tsBuildInfoFile": "../dist/server/tsconfig.tsbuildinfo",
     "composite": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- configure TS paths for server to resolve @shared modules from build output
- log the change in server actions log

## Testing
- `pnpm --version` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6850bc45a60c8330a344cd863911fc01